### PR TITLE
Add a way to retrieve the pydicom.FileDataset object from an instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,22 @@ for patient in patients:
    ...
 
    for study in patient.studies:
-      study.date  # Date as a datetime object
-      study.referring_physician_name
-      ...
+       study.date  # Date as a datetime object
+       study.referring_physician_name
+       ...
 
-      for series in study.series:
-         series.modality  # Should be 'RTDOSE' because of the series_filter parameters
-         ...
+       for series in study.series:
+           series.modality  # Should be 'RTDOSE' because of the series_filter parameters
+           ...
+           for instance in series.instances:
+               # Getting content by tag
+               instance.get_content_by_tag('ManufacturerModelName')  # == 'Pinnable3'
+               # Or
+               instance.get_content_by_tag('0008-1090')  # == 'Pinnable3'
+
+               pydicom_dataset = instance.get_pydicom()  # Retrieve the DICOM file and make a pydicom.FileDataset
+               pydicom_dataset.pixel_array  # You can access the pydicom.FileDataset attribute
+        
 ```
 
 

--- a/pyorthanc/instance.py
+++ b/pyorthanc/instance.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from typing import Dict, Any, List
 
+import pydicom
+
 from pyorthanc import util
 from pyorthanc.client import Orthanc
 
@@ -213,6 +215,10 @@ class Instance:
             self.id_,
             json={'Remove': remove, 'Replace': replace, 'Keep': keep, 'Force': force}
         )
+
+    def get_pydicom(self) -> pydicom.FileDataset:
+        """Retrieve a pydicom.FileDataset object corresponding to the instance."""
+        return util.get_pydicom(self.client, self.id_)
 
     def __repr__(self):
         return f'Instance(identifier={self.id_})'

--- a/pyorthanc/patient.py
+++ b/pyorthanc/patient.py
@@ -241,7 +241,7 @@ class Patient:
         return Patient(anonymous_patient['ID'], self.client)
 
     def __str__(self):
-        return f'Patient(PatientID={self.patient_id}, identifier={self.identifier})'
+        return f'Patient(PatientID={self.patient_id}, identifier={self.id_})'
 
     def remove_empty_studies(self) -> None:
         """Delete empty studies."""
@@ -251,3 +251,6 @@ class Patient:
         self._studies = list(filter(
             lambda s: s.series != [], self._studies
         ))
+
+    def __repr__(self):
+        return f'Patient(PatientID={self.patient_id}, identifier={self.id_})'

--- a/pyorthanc/util.py
+++ b/pyorthanc/util.py
@@ -1,5 +1,8 @@
 from datetime import datetime
-from typing import Optional
+from io import BytesIO
+from typing import Optional, io
+
+import pydicom
 
 from pyorthanc.async_client import AsyncOrthanc
 from pyorthanc.client import Orthanc
@@ -39,3 +42,12 @@ def sync_to_async(orthanc: Orthanc) -> AsyncOrthanc:
     async_orthanc._auth = orthanc.auth
 
     return async_orthanc
+
+
+def get_pydicom(orthanc: Orthanc, instance_identifier: str) -> pydicom.FileDataset:
+    """Get a pydicom.FileDataset from the instance's Orthanc identifier"""
+    dicom_bytes = orthanc.get_instances_id_file(instance_identifier)
+
+    return pydicom.dcmread(BytesIO(dicom_bytes))
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyorthanc"
-version = "1.11.3"
+version = "1.11.4"
 description = "Orthanc REST API python wrapper with additional utilities"
 authors = ["Gabriel Couture <gacou54@gmail.com>"]
 license = "MIT"

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import pydicom
 import pytest
 
 from pyorthanc import Orthanc, Instance
@@ -61,3 +62,10 @@ def test_anonymize(instance):
     anonymized_instance = instance.anonymize(remove=['InstanceCreationDate'])
 
     assert type(anonymized_instance) == bytes
+
+
+def test_pydicom(instance):
+    result = instance.get_pydicom()
+
+    assert isinstance(result, pydicom.FileDataset)
+    assert result.SOPInstanceUID == an_instance.INFORMATION['MainDicomTags']['SOPInstanceUID']

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,53 @@
+from datetime import datetime
+
+import pydicom
+import pytest
+
+from pyorthanc import Orthanc, AsyncOrthanc, util
+from tests.setup_server import ORTHANC_1, setup_data, clear_data
+from tests.data import an_instance
+
+
+@pytest.fixture
+def orthanc() -> Orthanc:
+    setup_data(ORTHANC_1)
+
+    yield Orthanc(url=ORTHANC_1.url, username=ORTHANC_1.username, password=ORTHANC_1.password)
+
+    clear_data(ORTHANC_1)
+
+
+@pytest.fixture
+def async_orthanc() -> AsyncOrthanc:
+    return AsyncOrthanc(url=ORTHANC_1.url)
+
+
+def test_async_to_sync(async_orthanc):
+    result = util.async_to_sync(async_orthanc)
+
+    assert isinstance(result, Orthanc)
+
+
+def test_sync_to_async(orthanc):
+    result = util.sync_to_async(orthanc)
+
+    assert isinstance(result, AsyncOrthanc)
+
+
+@pytest.mark.parametrize('date_str, time_str, expected', [
+    ('20100301', '170155', datetime(year=2010, month=3, day=1, hour=17, minute=1, second=55)),
+    ('20100301', 'bad_time', datetime(year=2010, month=3, day=1)),
+    ('20100301', None, datetime(year=2010, month=3, day=1)),
+    ('bad_date', None, None),
+])
+def test_make_datetime_from_dicom_date(date_str, time_str, expected):
+    result = util.make_datetime_from_dicom_date(date_str, time_str)
+
+    assert result == expected
+
+
+def test_get_pydicom(orthanc):
+    result = util.get_pydicom(orthanc, an_instance.IDENTIFIER)
+
+    assert isinstance(result, pydicom.FileDataset)
+    assert result.SOPInstanceUID == an_instance.INFORMATION['MainDicomTags']['SOPInstanceUID']


### PR DESCRIPTION
Add a way to retrieve the `pydicom.FileDataset` object from an instance. 
It becomes easier to manipulate certain tags and the DICOM data.