### PR TITLE
`find()` method now use the `Orthanc` object

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ Each patient is a tree. Layers in each tree have the following structure
 that correspond to the provided filter functions.
 
 ```python
-from pyorthanc import find
+from pyorthanc import find, Orthanc
 
+orthanc = Orthanc(url='http://localhost:8042/', username='username', password='password')
 patients = find(
-    orthanc_url='http://localhost:8042/',
-    auth=('username', 'password'),
+    orthanc=orthanc,
     series_filter=lambda s: s.modality == 'RTDOSE'  # Optional: filter with pyorthanc.Series object
 )
 

--- a/pyorthanc/async_client.py
+++ b/pyorthanc/async_client.py
@@ -15,7 +15,7 @@ from httpx._types import (
 class AsyncOrthanc(httpx.AsyncClient):
     """Orthanc API
 
-    version 1.11.2
+    version 1.11.3
     This is the full documentation of the [REST API](https://book.orthanc-server.com/users/rest.html) of Orthanc.<p>This reference is automatically generated from the source code of Orthanc. A [shorter cheat sheet](https://book.orthanc-server.com/users/rest-cheatsheet.html) is part of the Orthanc Book.<p>An earlier, manually crafted version from August 2019, is [still available](2019-08-orthanc-openapi.html), but is not up-to-date anymore ([source](https://groups.google.com/g/orthanc-users/c/NUiJTEICSl8/m/xKeqMrbqAAAJ)).
     
     """
@@ -29,7 +29,7 @@ class AsyncOrthanc(httpx.AsyncClient):
         """
         super().__init__()
         self.url = url
-        self.version = '1.11.2'
+        self.version = '1.11.3'
 
         if username and password:
             self.setup_credentials(username, password)
@@ -407,6 +407,7 @@ class AsyncOrthanc(httpx.AsyncClient):
             "PrivateCreator": The private creator to be used for private tags in `Replace`
             "Remove": List of additional tags to be removed from the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
             "Replace": Associative array to change the value of some DICOM tags in the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
+            "Transcode": Transcode the DICOM instances to the provided DICOM transfer syntax: https://book.orthanc-server.com/faq/transcoding.html
 
         Returns
         -------
@@ -2634,10 +2635,13 @@ class AsyncOrthanc(httpx.AsyncClient):
         json
             Dictionary with the following keys:
             "Asynchronous": If `true`, run the job in asynchronous mode, which means that the REST API call will immediately return, reporting the identifier of a job. Prefer this flavor wherever possible.
+            "CalledAet": Called AET that is used for this commands, defaults to `AET` configuration option. Allows you to overwrite the destination AET for a specific operation.
+            "Host": Host that is used for this commands, defaults to `Host` configuration option. Allows you to overwrite the destination host for a specific operation.
             "LocalAet": Local AET that is used for this commands, defaults to `DicomAet` configuration option. Ignored if `DicomModalities` already sets `LocalAet` for this modality.
             "MoveOriginatorAet": Move originator AET that is used for this commands, in order to fake a C-MOVE SCU
             "MoveOriginatorID": Move originator ID that is used for this commands, in order to fake a C-MOVE SCU
             "Permissive": If `true`, ignore errors during the individual steps of the job.
+            "Port": Port that is used for this commands, defaults to `Port` configuration option. Allows you to overwrite the destination port for a specific operation.
             "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
             "Resources": List of the Orthanc identifiers of all the DICOM resources to be sent
             "StorageCommitment": Whether to chain C-STORE with DICOM storage commitment to validate the success of the transmission: https://book.orthanc-server.com/users/storage-commitment.html#chaining-c-store-with-storage-commitment
@@ -2799,6 +2803,7 @@ class AsyncOrthanc(httpx.AsyncClient):
             "Remove": List of additional tags to be removed from the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
             "Replace": Associative array to change the value of some DICOM tags in the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
             "Synchronous": If `true`, run the job in synchronous mode, which means that the HTTP answer will directly contain the result of the job. This is the default, easy behavior, but it is *not* desirable for long jobs, as it might lead to network timeouts.
+            "Transcode": Transcode the DICOM instances to the provided DICOM transfer syntax: https://book.orthanc-server.com/faq/transcoding.html
 
         Returns
         -------
@@ -4673,6 +4678,7 @@ class AsyncOrthanc(httpx.AsyncClient):
             "Remove": List of additional tags to be removed from the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
             "Replace": Associative array to change the value of some DICOM tags in the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
             "Synchronous": If `true`, run the job in synchronous mode, which means that the HTTP answer will directly contain the result of the job. This is the default, easy behavior, but it is *not* desirable for long jobs, as it might lead to network timeouts.
+            "Transcode": Transcode the DICOM instances to the provided DICOM transfer syntax: https://book.orthanc-server.com/faq/transcoding.html
 
         Returns
         -------
@@ -5909,6 +5915,7 @@ class AsyncOrthanc(httpx.AsyncClient):
             "Remove": List of additional tags to be removed from the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
             "Replace": Associative array to change the value of some DICOM tags in the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
             "Synchronous": If `true`, run the job in synchronous mode, which means that the HTTP answer will directly contain the result of the job. This is the default, easy behavior, but it is *not* desirable for long jobs, as it might lead to network timeouts.
+            "Transcode": Transcode the DICOM instances to the provided DICOM transfer syntax: https://book.orthanc-server.com/faq/transcoding.html
 
         Returns
         -------
@@ -7135,6 +7142,7 @@ class AsyncOrthanc(httpx.AsyncClient):
             "Replace": Associative array to change the value of some DICOM tags in the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
             "Resources": List of the Orthanc identifiers of the patients/studies/series/instances of interest.
             "Synchronous": If `true`, run the job in synchronous mode, which means that the HTTP answer will directly contain the result of the job. This is the default, easy behavior, but it is *not* desirable for long jobs, as it might lead to network timeouts.
+            "Transcode": Transcode the DICOM instances to the provided DICOM transfer syntax: https://book.orthanc-server.com/faq/transcoding.html
 
         Returns
         -------

--- a/pyorthanc/client.py
+++ b/pyorthanc/client.py
@@ -15,7 +15,7 @@ from httpx._types import (
 class Orthanc(httpx.Client):
     """Orthanc API
 
-    version 1.11.2
+    version 1.11.3
     This is the full documentation of the [REST API](https://book.orthanc-server.com/users/rest.html) of Orthanc.<p>This reference is automatically generated from the source code of Orthanc. A [shorter cheat sheet](https://book.orthanc-server.com/users/rest-cheatsheet.html) is part of the Orthanc Book.<p>An earlier, manually crafted version from August 2019, is [still available](2019-08-orthanc-openapi.html), but is not up-to-date anymore ([source](https://groups.google.com/g/orthanc-users/c/NUiJTEICSl8/m/xKeqMrbqAAAJ)).
     
     """
@@ -29,7 +29,7 @@ class Orthanc(httpx.Client):
         """
         super().__init__()
         self.url = url
-        self.version = '1.11.2'
+        self.version = '1.11.3'
 
         if username and password:
             self.setup_credentials(username, password)
@@ -407,6 +407,7 @@ class Orthanc(httpx.Client):
             "PrivateCreator": The private creator to be used for private tags in `Replace`
             "Remove": List of additional tags to be removed from the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
             "Replace": Associative array to change the value of some DICOM tags in the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
+            "Transcode": Transcode the DICOM instances to the provided DICOM transfer syntax: https://book.orthanc-server.com/faq/transcoding.html
 
         Returns
         -------
@@ -2634,10 +2635,13 @@ class Orthanc(httpx.Client):
         json
             Dictionary with the following keys:
             "Asynchronous": If `true`, run the job in asynchronous mode, which means that the REST API call will immediately return, reporting the identifier of a job. Prefer this flavor wherever possible.
+            "CalledAet": Called AET that is used for this commands, defaults to `AET` configuration option. Allows you to overwrite the destination AET for a specific operation.
+            "Host": Host that is used for this commands, defaults to `Host` configuration option. Allows you to overwrite the destination host for a specific operation.
             "LocalAet": Local AET that is used for this commands, defaults to `DicomAet` configuration option. Ignored if `DicomModalities` already sets `LocalAet` for this modality.
             "MoveOriginatorAet": Move originator AET that is used for this commands, in order to fake a C-MOVE SCU
             "MoveOriginatorID": Move originator ID that is used for this commands, in order to fake a C-MOVE SCU
             "Permissive": If `true`, ignore errors during the individual steps of the job.
+            "Port": Port that is used for this commands, defaults to `Port` configuration option. Allows you to overwrite the destination port for a specific operation.
             "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
             "Resources": List of the Orthanc identifiers of all the DICOM resources to be sent
             "StorageCommitment": Whether to chain C-STORE with DICOM storage commitment to validate the success of the transmission: https://book.orthanc-server.com/users/storage-commitment.html#chaining-c-store-with-storage-commitment
@@ -2799,6 +2803,7 @@ class Orthanc(httpx.Client):
             "Remove": List of additional tags to be removed from the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
             "Replace": Associative array to change the value of some DICOM tags in the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
             "Synchronous": If `true`, run the job in synchronous mode, which means that the HTTP answer will directly contain the result of the job. This is the default, easy behavior, but it is *not* desirable for long jobs, as it might lead to network timeouts.
+            "Transcode": Transcode the DICOM instances to the provided DICOM transfer syntax: https://book.orthanc-server.com/faq/transcoding.html
 
         Returns
         -------
@@ -4673,6 +4678,7 @@ class Orthanc(httpx.Client):
             "Remove": List of additional tags to be removed from the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
             "Replace": Associative array to change the value of some DICOM tags in the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
             "Synchronous": If `true`, run the job in synchronous mode, which means that the HTTP answer will directly contain the result of the job. This is the default, easy behavior, but it is *not* desirable for long jobs, as it might lead to network timeouts.
+            "Transcode": Transcode the DICOM instances to the provided DICOM transfer syntax: https://book.orthanc-server.com/faq/transcoding.html
 
         Returns
         -------
@@ -5909,6 +5915,7 @@ class Orthanc(httpx.Client):
             "Remove": List of additional tags to be removed from the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
             "Replace": Associative array to change the value of some DICOM tags in the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
             "Synchronous": If `true`, run the job in synchronous mode, which means that the HTTP answer will directly contain the result of the job. This is the default, easy behavior, but it is *not* desirable for long jobs, as it might lead to network timeouts.
+            "Transcode": Transcode the DICOM instances to the provided DICOM transfer syntax: https://book.orthanc-server.com/faq/transcoding.html
 
         Returns
         -------
@@ -7135,6 +7142,7 @@ class Orthanc(httpx.Client):
             "Replace": Associative array to change the value of some DICOM tags in the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
             "Resources": List of the Orthanc identifiers of the patients/studies/series/instances of interest.
             "Synchronous": If `true`, run the job in synchronous mode, which means that the HTTP answer will directly contain the result of the job. This is the default, easy behavior, but it is *not* desirable for long jobs, as it might lead to network timeouts.
+            "Transcode": Transcode the DICOM instances to the provided DICOM transfer syntax: https://book.orthanc-server.com/faq/transcoding.html
 
         Returns
         -------

--- a/pyorthanc/series.py
+++ b/pyorthanc/series.py
@@ -189,3 +189,7 @@ class Series:
 
     def __repr__(self):
         return f'Series(identifier={self.id_})'
+
+    def remove_empty_instances(self) -> None:
+        self._instances = [i for i in self._instances if i is not None]
+

--- a/pyorthanc/study.py
+++ b/pyorthanc/study.py
@@ -211,6 +211,9 @@ class Study:
 
     def remove_empty_series(self) -> None:
         """Delete empty series."""
+        for series in self._series:
+            series.remove_empty_instances()
+
         self._series = list(filter(
             lambda series: series.instances != [],
             self._series

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pyorthanc import AsyncOrthanc, Instance, Orthanc, Patient, Series, Study, filtering
+from pyorthanc.util import make_datetime_from_dicom_date
 from tests.data import a_patient, a_series, a_study, an_instance
 from tests.setup_server import ORTHANC_1, clear_data, setup_data
 
@@ -23,32 +24,45 @@ def async_client():
     clear_data(ORTHANC_1)
 
 
-@pytest.mark.parametrize('async_mode, series_filter, expected_nbr_of_series', [
-    (False, None, 3),
-    (False, lambda s: s.modality == 'RTDOSE', 1),
-    (True, None, 3),
-    (True, lambda s: s.modality == 'RTDOSE', 1),
-]
-                         )
-def test_find(client, async_mode, series_filter, expected_nbr_of_series):
+@pytest.mark.parametrize('patient_filter, study_filter, series_filter, instance_filter, expected_nbr_of_patient, expected_nbr_of_series', [
+    (None, None, None, None, 1, 3),
+    (lambda p: p.name == 'MR-R', None, None, None, 1, 3),
+    (lambda p: p.name == 'NOT_EXISTING_PATIENT', None, None, None, 0, 0),
+    (None, lambda s: s.date == make_datetime_from_dicom_date('20100223'), None, None, 1, 3),
+    (None, lambda s: s.date == make_datetime_from_dicom_date('19990101'), None, None, 0, 0),  # Fake date.
+    (None, None, lambda s: s.modality == 'RTDOSE', None, 1, 1),
+    (None, None, lambda s: s.modality == 'NOT_EXISTING_MODALITY', None, 0, 0),
+    (None, None, None, lambda i: i.creation_date == make_datetime_from_dicom_date('20100301', '170155'), 1, 3),
+    (None, None, None, lambda i: i.creation_date == make_datetime_from_dicom_date('19990101'), 0, 0),  # Fake date.
+])
+def test_find(client, patient_filter, study_filter, series_filter, instance_filter, expected_nbr_of_patient, expected_nbr_of_series):
     patients = filtering.find(
-        orthanc_url=client.url,
-        auth=(ORTHANC_1.username, ORTHANC_1.password),
-        async_mode=async_mode,
-        series_filter=series_filter
+        orthanc=client,
+        patient_filter=patient_filter,
+        study_filter=study_filter,
+        series_filter=series_filter,
+        instance_filter=instance_filter
     )
 
     assert type(patients) == list
-    assert type(patients[0]) == Patient
-    assert patients[0].patient_id == a_patient.ID
+    assert len(patients) == expected_nbr_of_patient
+    if expected_nbr_of_patient != 0:
+        patient = patients[0]
+        assert type(patient) == Patient
+        assert patient.patient_id == a_patient.ID
 
-    assert type(patients[0].studies[0]) == Study
-    assert patients[0].studies[0].uid == a_study.INFORMATION['MainDicomTags']['StudyInstanceUID']
-    assert len(patients[0].studies[0].series) == expected_nbr_of_series
+        assert len(patient.studies) != 0
+        study = patients[0].studies[0]
+        assert type(study) == Study
+        assert study.uid == a_study.INFORMATION['MainDicomTags']['StudyInstanceUID']
+        assert len(study.series) == expected_nbr_of_series
 
-    assert type(patients[0].studies[0].series[0]) == Series
-    series = [s for s in patients[0].studies[0].series if s.modality == 'RTDOSE'][0]
-    assert series.uid == a_series.INFORMATION['MainDicomTags']['SeriesInstanceUID']
+        assert len(study.series) != 0
+        series = patients[0].studies[0].series[0]
+        assert type(series) == Series
+        assert series.uid == a_series.INFORMATION['MainDicomTags']['SeriesInstanceUID']
 
-    assert type(series.instances[0]) == Instance
-    assert series.instances[0].uid == an_instance.INFORMATION['MainDicomTags']['SOPInstanceUID']
+        assert len(series.instances) != 0
+        instance = series.instances[0]
+        assert type(instance) == Instance
+        assert instance.uid == an_instance.INFORMATION['MainDicomTags']['SOPInstanceUID']

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -58,7 +58,7 @@ def test_find(client, patient_filter, study_filter, series_filter, instance_filt
         assert len(study.series) == expected_nbr_of_series
 
         assert len(study.series) != 0
-        series = patients[0].studies[0].series[0]
+        series = [s for s in patients[0].studies[0].series if s.modality == 'RTDOSE'][0]  # Ensure that the correct series is selected
         assert type(series) == Series
         assert series.uid == a_series.INFORMATION['MainDicomTags']['SeriesInstanceUID']
 
@@ -102,7 +102,7 @@ def test_find_async(async_client, patient_filter, study_filter, series_filter, i
         assert len(study.series) == expected_nbr_of_series
 
         assert len(study.series) != 0
-        series = patients[0].studies[0].series[0]
+        series = [s for s in patients[0].studies[0].series if s.modality == 'RTDOSE'][0]  # Ensure that the correct series is selected
         assert type(series) == Series
         assert series.uid == a_series.INFORMATION['MainDicomTags']['SeriesInstanceUID']
 

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -66,3 +66,47 @@ def test_find(client, patient_filter, study_filter, series_filter, instance_filt
         instance = series.instances[0]
         assert type(instance) == Instance
         assert instance.uid == an_instance.INFORMATION['MainDicomTags']['SOPInstanceUID']
+
+
+@pytest.mark.parametrize('patient_filter, study_filter, series_filter, instance_filter, expected_nbr_of_patient, expected_nbr_of_series', [
+    (None, None, None, None, 1, 3),
+    (lambda p: p.name == 'MR-R', None, None, None, 1, 3),
+    (lambda p: p.name == 'NOT_EXISTING_PATIENT', None, None, None, 0, 0),
+    (None, lambda s: s.date == make_datetime_from_dicom_date('20100223'), None, None, 1, 3),
+    (None, lambda s: s.date == make_datetime_from_dicom_date('19990101'), None, None, 0, 0),  # Fake date.
+    (None, None, lambda s: s.modality == 'RTDOSE', None, 1, 1),
+    (None, None, lambda s: s.modality == 'NOT_EXISTING_MODALITY', None, 0, 0),
+    (None, None, None, lambda i: i.creation_date == make_datetime_from_dicom_date('20100301', '170155'), 1, 3),
+    (None, None, None, lambda i: i.creation_date == make_datetime_from_dicom_date('19990101'), 0, 0),  # Fake date.
+])
+def test_find_async(async_client, patient_filter, study_filter, series_filter, instance_filter, expected_nbr_of_patient, expected_nbr_of_series):
+    patients = filtering.find(
+        orthanc=async_client,
+        patient_filter=patient_filter,
+        study_filter=study_filter,
+        series_filter=series_filter,
+        instance_filter=instance_filter
+    )
+
+    assert type(patients) == list
+    assert len(patients) == expected_nbr_of_patient
+    if expected_nbr_of_patient != 0:
+        patient = patients[0]
+        assert type(patient) == Patient
+        assert patient.patient_id == a_patient.ID
+
+        assert len(patient.studies) != 0
+        study = patients[0].studies[0]
+        assert type(study) == Study
+        assert study.uid == a_study.INFORMATION['MainDicomTags']['StudyInstanceUID']
+        assert len(study.series) == expected_nbr_of_series
+
+        assert len(study.series) != 0
+        series = patients[0].studies[0].series[0]
+        assert type(series) == Series
+        assert series.uid == a_series.INFORMATION['MainDicomTags']['SeriesInstanceUID']
+
+        assert len(series.instances) != 0
+        instance = series.instances[0]
+        assert type(instance) == Instance
+        assert instance.uid == an_instance.INFORMATION['MainDicomTags']['SOPInstanceUID']

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -63,3 +63,13 @@ def test_anonymize(series):
            a_series.INFORMATION['MainDicomTags']['StationName']
     assert anonymized_series.get_main_information()['MainDicomTags']['StationName'] == \
            a_series.INFORMATION['MainDicomTags']['StationName']
+
+
+def test_remote_empty_instances(series):
+    series.build_instances()
+
+    # Putting an empty instance
+    series._instances = [None]
+
+    series.remove_empty_instances()
+    assert series.instances == []


### PR DESCRIPTION
The `find()` method now takes an `Orthanc` object. This allows configuring the Orthanc's client for the HTTP calls inside the `find` method. 

The `find` method now accepts an `instance_filter` parameter as well.

Also, update to Orthanc 1.11.3.

Related #16 