### PR TITLE
Client supports all httpx.Client parameters

### DIFF
--- a/pyorthanc/__init__.py
+++ b/pyorthanc/__init__.py
@@ -8,6 +8,7 @@ from .resources import Instance, Patient, Series, Study
 from .retrieve import retrieve_and_write_instance, retrieve_and_write_patient, retrieve_and_write_patients, \
     retrieve_and_write_series, retrieve_and_write_study
 
+
 __all__ = [
     'AsyncOrthanc',
     'Orthanc',

--- a/pyorthanc/async_client.py
+++ b/pyorthanc/async_client.py
@@ -35,7 +35,7 @@ class AsyncOrthanc(httpx.AsyncClient):
         *args, **kwargs
             Parameters passed to the httpx.Client (headers, timeout, etc.)
         """
-        super().__init__()
+        super().__init__(*args, **kwargs)
         self.url = url
         self.version = '1.12.1'
         self.return_raw_response = return_raw_response

--- a/pyorthanc/async_client.py
+++ b/pyorthanc/async_client.py
@@ -20,7 +20,7 @@ class AsyncOrthanc(httpx.AsyncClient):
     
     """
 
-    def __init__(self, url: str, username: Optional[str] = None, password: Optional[str] = None, headers: Optional[HeaderTypes] = None, return_raw_response: bool = False):
+    def __init__(self, url: str, username: Optional[str] = None, password: Optional[str] = None, return_raw_response: bool = False, *args, **kwargs):
         """
         Parameters
         ----------
@@ -30,10 +30,10 @@ class AsyncOrthanc(httpx.AsyncClient):
             Orthanc's username
         password
             Orthanc's password
-        headers
-            Headers that will be share in all requests
         return_raw_response
             All Orthanc's methods will return a raw httpx.Response rather than the serialized result
+        *args, **kwargs
+            Parameters passed to the httpx.Client (headers, timeout, etc.)
         """
         super().__init__()
         self.url = url
@@ -42,9 +42,6 @@ class AsyncOrthanc(httpx.AsyncClient):
 
         if username and password:
             self.setup_credentials(username, password)
-
-        if headers is not None:
-            self.headers = headers
 
     def setup_credentials(self, username: str, password: str) -> None:
         """Set credentials needed for HTTP requests"""

--- a/pyorthanc/client.py
+++ b/pyorthanc/client.py
@@ -20,7 +20,7 @@ class Orthanc(httpx.Client):
     
     """
 
-    def __init__(self, url: str, username: Optional[str] = None, password: Optional[str] = None, headers: Optional[HeaderTypes] = None, return_raw_response: bool = False):
+    def __init__(self, url: str, username: Optional[str] = None, password: Optional[str] = None, return_raw_response: bool = False, *args, **kwargs):
         """
         Parameters
         ----------
@@ -30,21 +30,18 @@ class Orthanc(httpx.Client):
             Orthanc's username
         password
             Orthanc's password
-        headers
-            Headers that will be share in all requests
         return_raw_response
             All Orthanc's methods will return a raw httpx.Response rather than the serialized result
+        *args, **kwargs
+            Parameters passed to the httpx.Client (headers, timeout, etc.)
         """
-        super().__init__()
+        super().__init__(*args, **kwargs)
         self.url = url
         self.version = '1.12.1'
         self.return_raw_response = return_raw_response
 
         if username and password:
             self.setup_credentials(username, password)
-
-        if headers is not None:
-            self.headers = headers
 
     def setup_credentials(self, username: str, password: str) -> None:
         """Set credentials needed for HTTP requests"""

--- a/pyorthanc/find.py
+++ b/pyorthanc/find.py
@@ -1,10 +1,11 @@
 from typing import Dict, List, Union
 
-from pyorthanc.resources.instance import Instance
-from pyorthanc.resources.patient import Patient
-from pyorthanc.resources.series import Series
-from pyorthanc.resources.study import Study
 from .client import Orthanc
+from .resources.instance import Instance
+from .resources.patient import Patient
+from .resources.resource import Resource
+from .resources.series import Series
+from .resources.study import Study
 
 DEFAULT_RESOURCES_LIMIT = 1_000
 
@@ -193,7 +194,7 @@ def query_orthanc(client: Orthanc,
                   labels_constraint: str = 'All',
                   limit: int = DEFAULT_RESOURCES_LIMIT,
                   since: int = 0,
-                  retrieve_all_resources: bool = True) -> List[Union[Patient, Study, Series, Instance]]:
+                  retrieve_all_resources: bool = True) -> List[Resource]:
     """
 
     Parameters
@@ -217,7 +218,7 @@ def query_orthanc(client: Orthanc,
 
     Returns
     -------
-    List[Union[Patient, Study, Series, Instance]]
+    List[Resource]
         List of resources that fit the provided criteria.
 
     Examples

--- a/pyorthanc/resources/patient.py
+++ b/pyorthanc/resources/patient.py
@@ -98,14 +98,16 @@ class Patient(Resource):
 
         Examples
         --------
-        >>> from pyorthanc import Orthanc, Patient
-        >>> a_patient = Patient(
-        ...     'A_PATIENT_IDENTIFIER',
-        ...     Orthanc('http://localhost:8042')
-        ... )
-        >>> bytes_content = a_patient.get_zip()
-        >>> with open('patient_zip_file_path.zip', 'wb') as file_handler:
-        ...     file_handler.write(bytes_content)
+        ```python
+        from pyorthanc import Orthanc, Patient
+        a_patient = Patient(
+            'A_PATIENT_IDENTIFIER',
+            Orthanc('http://localhost:8042')
+        )
+        bytes_content = a_patient.get_zip()
+        with open('patient_zip_file_path.zip', 'wb') as file_handler:
+            file_handler.write(bytes_content)
+        ```
 
         """
         return self.client.get_patients_id_archive(self.id_)

--- a/pyorthanc/resources/series.py
+++ b/pyorthanc/resources/series.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 from typing import Dict, List
 
-from pyorthanc import util
 from .instance import Instance
 from .resource import Resource
+from .. import util
 
 
 class Series(Resource):
@@ -172,14 +172,16 @@ class Series(Resource):
 
         Examples
         --------
-        >>> from pyorthanc import Orthanc, Series
-        >>> a_series = Series(
-        ...     'SERIES_IDENTIFIER',
-        ...     Orthanc('http://localhost:8042')
-        ... )
-        >>> bytes_content = a_series.get_zip()
-        >>> with open('series_zip_file_path.zip', 'wb') as file_handler:
-        ...     file_handler.write(bytes_content)
+        ```python
+        from pyorthanc import Orthanc, Series
+        a_series = Series(
+            'SERIES_IDENTIFIER',
+            Orthanc('http://localhost:8042')
+        )
+        bytes_content = a_series.get_zip()
+        with open('series_zip_file_path.zip', 'wb') as file_handler:
+            file_handler.write(bytes_content)
+        ```
 
         """
         return self.client.get_series_id_archive(self.id_)

--- a/pyorthanc/resources/study.py
+++ b/pyorthanc/resources/study.py
@@ -1,10 +1,9 @@
 from datetime import datetime
 from typing import Dict, List
 
-from pyorthanc import util
-from pyorthanc.util import make_datetime_from_dicom_date
 from .resource import Resource
 from .series import Series
+from .. import util
 
 
 class Study(Resource):
@@ -56,7 +55,7 @@ class Study(Resource):
         date_string = self.get_main_information()['MainDicomTags']['StudyDate']
         time_string = self.get_main_information()['MainDicomTags']['StudyTime']
 
-        return make_datetime_from_dicom_date(date_string, time_string)
+        return util.make_datetime_from_dicom_date(date_string, time_string)
 
     @property
     def study_id(self) -> str:
@@ -192,14 +191,16 @@ class Study(Resource):
 
         Examples
         --------
-        >>> from pyorthanc import Orthanc, Study
-        >>> a_study = Study(
-        ...     'STUDY_IDENTIFIER',
-        ...     Orthanc('http://localhost:8042')
-        ... )
-        >>> bytes_content = a_study.get_zip()
-        >>> with open('study_zip_file_path.zip', 'wb') as file_handler:
-        ...     file_handler.write(bytes_content)
+        ```python
+        from pyorthanc import Orthanc, Study
+        a_study = Study(
+            'STUDY_IDENTIFIER',
+            Orthanc('http://localhost:8042')
+        )
+        bytes_content = a_study.get_zip()
+        with open('study_zip_file_path.zip', 'wb') as file_handler:
+            file_handler.write(bytes_content)
+        ```
 
         """
         return self.client.get_studies_id_archive(self.id_)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ pydicom = "^2.3.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.0"
-simple-openapi-client = "^0.5.0"
+simple-openapi-client = "^0.5.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ pydicom = "^2.3.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.0"
-simple-openapi-client = "^0.5.1"
+simple-openapi-client = "^0.5.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
New features
- Orthanc Client and Async Orthanc client now accept all `httpx.Client` and `httpx.AsyncClient` parameters (e.g. headers, timeout)

related to #24 