### PR TITLE
Fix lock state on query and __repr__ of resources

### DIFF
--- a/pyorthanc/__init__.py
+++ b/pyorthanc/__init__.py
@@ -1,4 +1,3 @@
-from pyorthanc.resources.study import Study
 from .async_client import AsyncOrthanc
 from .client import Orthanc
 from .filtering import build_patient_forest, find, trim_patients

--- a/pyorthanc/resources/instance.py
+++ b/pyorthanc/resources/instance.py
@@ -203,6 +203,3 @@ class Instance(Resource):
     def get_pydicom(self) -> pydicom.FileDataset:
         """Retrieve a pydicom.FileDataset object corresponding to the instance."""
         return util.get_pydicom(self.client, self.id_)
-
-    def __repr__(self):
-        return f'Instance(identifier={self.id_})'

--- a/pyorthanc/resources/patient.py
+++ b/pyorthanc/resources/patient.py
@@ -275,6 +275,3 @@ class Patient(Resource):
             study.remove_empty_series()
 
         self._child_resources = [study for study in self._child_resources if study._child_resources != []]
-
-    def __repr__(self):
-        return f'Patient(PatientID={self.patient_id}, identifier={self.id_})'

--- a/pyorthanc/resources/resource.py
+++ b/pyorthanc/resources/resource.py
@@ -38,5 +38,11 @@ class Resource:
         """
         return self.id_
 
+    def get_main_information(self):
+        raise NotImplementedError
+
     def __eq__(self, other: 'Resource') -> bool:
         return self.id_ == other.id_
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}({self.id_})'

--- a/pyorthanc/resources/series.py
+++ b/pyorthanc/resources/series.py
@@ -186,9 +186,6 @@ class Series(Resource):
         """
         return self.client.get_series_id_archive(self.id_)
 
-    def __repr__(self):
-        return f'Series(identifier={self.id_})'
-
     def remove_empty_instances(self) -> None:
         if self._child_resources is not None:
             self._child_resources = [i for i in self._child_resources if i is not None]

--- a/pyorthanc/resources/study.py
+++ b/pyorthanc/resources/study.py
@@ -214,6 +214,3 @@ class Study(Resource):
             series.remove_empty_instances()
 
         self._child_resources = [series for series in self._child_resources if series._child_resources != []]
-
-    def __repr__(self):
-        return f'Study(StudyId={self.study_id}, identifier={self.id_})'

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -84,35 +84,37 @@ def test_find_instance(client_with_data_and_labels, query, labels, expected):
     assert [instance.id_ for instance in result] == expected
 
 
-@pytest.mark.parametrize('level, query, labels, labels_constraint, limit, since, retrieve_all_resources, expected', [
+@pytest.mark.parametrize('level, query, labels, labels_constraint, limit, since, retrieve_all_resources, lock, expected', [
     # On level
-    ('Patient', None, None, 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, [a_patient.IDENTIFIER]),
-    ('Study', None, None, 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, [a_study.IDENTIFIER]),
-    ('Series', None, None, 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, ['60108266-ece4d8f7-7b028286-a7b61f25-c6d33f0b', 'c4c1fcc9-ae63f793-40cbcf25-fbd3efe5-ad72ff06', 'e2a7df26-99673e0f-05aa84cd-c89677c0-634a2a96']),
-    ('Instance', None, None, 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, ['22dcf059-8fd3ade7-efb39ca3-7f46b248-0200abc9', 'da2024f5-606f9e83-41b012bb-9dced1ea-77bcd599', '348befe7-5be5ff53-70120381-3baa0cc2-e4e04220']),
+    ('Patient', None, None, 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, False, [a_patient.IDENTIFIER]),
+    ('Study', None, None, 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, False, [a_study.IDENTIFIER]),
+    ('Series', None, None, 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, False, ['60108266-ece4d8f7-7b028286-a7b61f25-c6d33f0b', 'c4c1fcc9-ae63f793-40cbcf25-fbd3efe5-ad72ff06', 'e2a7df26-99673e0f-05aa84cd-c89677c0-634a2a96']),
+    ('Instance', None, None, 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, False, ['22dcf059-8fd3ade7-efb39ca3-7f46b248-0200abc9', 'da2024f5-606f9e83-41b012bb-9dced1ea-77bcd599', '348befe7-5be5ff53-70120381-3baa0cc2-e4e04220']),
     # On query
-    ('Patient', {}, None, 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, [a_patient.IDENTIFIER]),
-    ('Patient', {'PatientID': '*'}, None, 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, [a_patient.IDENTIFIER]),
-    ('Patient', {'PatientID': 'NOT_EXISTING_PATIENT'}, None, 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, []),
+    ('Patient', {}, None, 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, False, [a_patient.IDENTIFIER]),
+    ('Patient', {'PatientID': '*'}, None, 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, False, [a_patient.IDENTIFIER]),
+    ('Patient', {'PatientID': 'NOT_EXISTING_PATIENT'}, None, 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, False, []),
     # On labels
-    ('Patient', None, LABEL_PATIENT, 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, [a_patient.IDENTIFIER]),
-    ('Patient', None, [LABEL_PATIENT], 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, [a_patient.IDENTIFIER]),
-    ('Patient', None, '', 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, [a_patient.IDENTIFIER]),
-    ('Patient', None, [], 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, [a_patient.IDENTIFIER]),
-    ('Patient', None, ['NOT_EXISTING_LABEL'], 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, []),
+    ('Patient', None, LABEL_PATIENT, 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, False, [a_patient.IDENTIFIER]),
+    ('Patient', None, [LABEL_PATIENT], 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, False, [a_patient.IDENTIFIER]),
+    ('Patient', None, '', 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, False, [a_patient.IDENTIFIER]),
+    ('Patient', None, [], 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, False, [a_patient.IDENTIFIER]),
+    ('Patient', None, ['NOT_EXISTING_LABEL'], 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, False, []),
     # On labels_constraint
-    ('Patient', None, [LABEL_PATIENT], 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, [a_patient.IDENTIFIER]),
-    ('Patient', None, [LABEL_PATIENT, 'BAD_LABEL'], 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, []),
-    ('Patient', None, [LABEL_PATIENT, 'BAD_LABEL'], 'Any', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, [a_patient.IDENTIFIER]),
-    ('Patient', None, [LABEL_PATIENT], 'None', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, []),
-    ('Patient', None, None, 'None', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, [a_patient.IDENTIFIER]),
+    ('Patient', None, [LABEL_PATIENT], 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, False, [a_patient.IDENTIFIER]),
+    ('Patient', None, [LABEL_PATIENT, 'BAD_LABEL'], 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, False, []),
+    ('Patient', None, [LABEL_PATIENT, 'BAD_LABEL'], 'Any', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, False, [a_patient.IDENTIFIER]),
+    ('Patient', None, [LABEL_PATIENT], 'None', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, False, []),
+    ('Patient', None, None, 'None', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, False, [a_patient.IDENTIFIER]),
     # On limit and since
-    ('Series', None, None, 'All', DEFAULT_RESOURCES_LIMIT, 1, False, ['c4c1fcc9-ae63f793-40cbcf25-fbd3efe5-ad72ff06', 'e2a7df26-99673e0f-05aa84cd-c89677c0-634a2a96']),
-    ('Series', None, None, 'All', 1, DEFAULT_SINCE, False, ['60108266-ece4d8f7-7b028286-a7b61f25-c6d33f0b']),
-    ('Series', None, None, 'All', 1, DEFAULT_SINCE, True, ['60108266-ece4d8f7-7b028286-a7b61f25-c6d33f0b', 'c4c1fcc9-ae63f793-40cbcf25-fbd3efe5-ad72ff06', 'e2a7df26-99673e0f-05aa84cd-c89677c0-634a2a96']),
+    ('Series', None, None, 'All', DEFAULT_RESOURCES_LIMIT, 1, False, False, ['c4c1fcc9-ae63f793-40cbcf25-fbd3efe5-ad72ff06', 'e2a7df26-99673e0f-05aa84cd-c89677c0-634a2a96']),
+    ('Series', None, None, 'All', 1, DEFAULT_SINCE, False, False, ['60108266-ece4d8f7-7b028286-a7b61f25-c6d33f0b']),
+    ('Series', None, None, 'All', 1, DEFAULT_SINCE, True, False, ['60108266-ece4d8f7-7b028286-a7b61f25-c6d33f0b', 'c4c1fcc9-ae63f793-40cbcf25-fbd3efe5-ad72ff06', 'e2a7df26-99673e0f-05aa84cd-c89677c0-634a2a96']),
+    # On lock
+    ('Patient', None, [LABEL_PATIENT], 'All', DEFAULT_RESOURCES_LIMIT, DEFAULT_SINCE, False, True, [a_patient.IDENTIFIER]),
 
 ])
-def test_query_orthanc(client_with_data_and_labels, level, query, labels, labels_constraint, limit, since, retrieve_all_resources, expected):
+def test_query_orthanc(client_with_data_and_labels, level, query, labels, labels_constraint, limit, since, retrieve_all_resources, lock, expected):
     result = query_orthanc(
         client=client_with_data_and_labels,
         level=level,
@@ -121,10 +123,16 @@ def test_query_orthanc(client_with_data_and_labels, level, query, labels, labels
         labels_constraint=labels_constraint,
         limit=limit,
         since=since,
-        retrieve_all_resources=retrieve_all_resources
+        retrieve_all_resources=retrieve_all_resources,
+        lock=lock
     )
 
     assert [resource.id_ for resource in result] == expected
+    for resource in result:
+        if lock:
+            assert isinstance(resource._information, dict)
+        else:
+            assert resource._information is None
 
 
 @pytest.mark.parametrize('level, labels_constraint', [

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -26,6 +26,7 @@ def test_attributes(instance):
 
     assert '0008,0012' in instance.tags.keys()
     assert 'Value' in instance.tags['0008,0012'].keys()
+    assert str(instance) == f'Instance({an_instance.IDENTIFIER})'
 
 
 def test_get_tag_content(instance):

--- a/tests/test_patient.py
+++ b/tests/test_patient.py
@@ -19,6 +19,7 @@ def test_attributes(patient):
     assert patient.labels == [LABEL_PATIENT]
     assert not patient.is_stable
     assert isinstance(patient.last_update, datetime)
+    assert str(patient) == f'Patient({a_patient.IDENTIFIER})'
 
     assert [s.identifier for s in patient.studies] == a_patient.INFORMATION['Studies']
 

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -20,6 +20,7 @@ def test_attributes(series):
     assert not series.is_stable
     assert isinstance(series.last_update, datetime)
     assert series.instances != []
+    assert str(series) == f'Series({a_series.IDENTIFIER})'
 
 
 def test_zip(series):

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -23,6 +23,7 @@ def test_attributes(study):
     assert not study.is_stable
     assert isinstance(study.last_update, datetime)
     assert study.series != []
+    assert str(study) == f'Study({a_study.IDENTIFIER})'
 
 
 def test_remove_empty_series(study):


### PR DESCRIPTION
- Add a `lock` parameter on `query_orthanc()` (and fix the lock bug at the same time)
- Improve the resources `__repr__` (related to #28)