### PR TITLE
Adding check for return_raw_response everywhere

### DIFF
--- a/pyorthanc/_filtering.py
+++ b/pyorthanc/_filtering.py
@@ -2,12 +2,13 @@ import asyncio
 import warnings
 from typing import Callable, Dict, List, Optional, Union
 
-from .async_client import AsyncOrthanc
-from .client import Orthanc
+from . import util
 from ._resources.instance import Instance
 from ._resources.patient import Patient
 from ._resources.series import Series
 from ._resources.study import Study
+from .async_client import AsyncOrthanc
+from .client import Orthanc
 from .util import async_to_sync
 
 
@@ -56,6 +57,9 @@ def find(orthanc: Union[Orthanc, AsyncOrthanc],
     List[Patient]
         List of patients that respect .
     """
+    # In this function, client that return raw responses are not supported.
+    orthanc = util.ensure_non_raw_response(orthanc)
+
     if isinstance(orthanc, AsyncOrthanc):
         return asyncio.run(_async_find(
             async_orthanc=orthanc,

--- a/pyorthanc/_find.py
+++ b/pyorthanc/_find.py
@@ -1,5 +1,6 @@
 from typing import Dict, List, Union
 
+from . import util
 from ._resources.instance import Instance
 from ._resources.patient import Patient
 from ._resources.resource import Resource
@@ -196,7 +197,7 @@ def query_orthanc(client: Orthanc,
                   since: int = 0,
                   retrieve_all_resources: bool = True,
                   lock: bool = False) -> List[Resource]:
-    """
+    """Query data in the Orthanc server
 
     Parameters
     ----------
@@ -242,6 +243,9 @@ def query_orthanc(client: Orthanc,
     """
     _validate_level(level)
     _validate_labels_constraint(labels_constraint)
+
+    # In this function, client that return raw responses are not supported.
+    client = util.ensure_non_raw_response(client)
 
     data = {
         'Expand': True,

--- a/pyorthanc/_modality.py
+++ b/pyorthanc/_modality.py
@@ -2,6 +2,7 @@ from typing import Dict
 
 import httpx
 
+from . import util
 from .client import Orthanc
 
 
@@ -18,6 +19,8 @@ class Modality:
         modality
             Remote modality.
         """
+        client = util.ensure_non_raw_response(client)
+
         self.client = client
         self.modality = modality
 

--- a/pyorthanc/_resources/resource.py
+++ b/pyorthanc/_resources/resource.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from .. import errors
+from .. import errors, util
 from ..client import Orthanc
 
 
@@ -21,6 +21,8 @@ class Resource:
             or all of those children. "lock=True" is notably used for the "find" function,
             so that only the filtered resources are kept.
         """
+        client = util.ensure_non_raw_response(client)
+
         self.id_ = id_
         self.client = client
 

--- a/pyorthanc/jobs.py
+++ b/pyorthanc/jobs.py
@@ -132,6 +132,8 @@ class Job:
     """Job class to follow a Job in Orthanc"""
 
     def __init__(self, id_: str, client: Orthanc):
+        client = util.ensure_non_raw_response(client)
+
         self.id_ = id_
         self.client = client
 

--- a/pyorthanc/util.py
+++ b/pyorthanc/util.py
@@ -59,7 +59,7 @@ def ensure_non_raw_response(client: Orthanc) -> Orthanc:
             'client.return_raw_response is True, which is currently not supported for this class/function. '
             'Will use the client with client.return_raw_response=False'
         )
-        client = copy.deepcopy(client)
+        client = copy.copy(client)
         client.return_raw_response = False
 
     return client

--- a/pyorthanc/util.py
+++ b/pyorthanc/util.py
@@ -1,3 +1,5 @@
+import copy
+import warnings
 from datetime import datetime
 from io import BytesIO
 from typing import Optional
@@ -51,3 +53,14 @@ def get_pydicom(orthanc: Orthanc, instance_identifier: str) -> pydicom.FileDatas
     return pydicom.dcmread(BytesIO(dicom_bytes))
 
 
+
+def ensure_non_raw_response(client: Orthanc) -> Orthanc:
+    if client.return_raw_response:
+        warnings.warn(
+            'client.return_raw_response is True, which is currently not supported for this class/function. '
+            'Will use the client with client.return_raw_response=False'
+        )
+        client = copy.deepcopy(client)
+        client.return_raw_response = False
+
+    return client

--- a/pyorthanc/util.py
+++ b/pyorthanc/util.py
@@ -53,7 +53,6 @@ def get_pydicom(orthanc: Orthanc, instance_identifier: str) -> pydicom.FileDatas
     return pydicom.dcmread(BytesIO(dicom_bytes))
 
 
-
 def ensure_non_raw_response(client: Orthanc) -> Orthanc:
     if client.return_raw_response:
         warnings.warn(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyorthanc"
-version = "1.12.2"
+version = "1.12.3"
 description = "Orthanc REST API python wrapper with additional utilities"
 authors = [
     "Gabriel Couture <gacou54@gmail.com>",

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -42,6 +42,7 @@ def test_get_pydicom(client_with_data):
 def test_ensure_non_raw_response(client, return_raw_response):
     client.return_raw_response = return_raw_response
 
-    client = util.ensure_non_raw_response(client)
+    new_client = util.ensure_non_raw_response(client)
 
-    assert client.return_raw_response
+    assert not new_client.return_raw_response
+    assert client.return_raw_response == return_raw_response

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import pydicom
 import pytest
 
-from pyorthanc import Orthanc, AsyncOrthanc, util
+from pyorthanc import AsyncOrthanc, Orthanc, util
 from .data import an_instance
 
 
@@ -36,3 +36,12 @@ def test_get_pydicom(client_with_data):
 
     assert isinstance(result, pydicom.FileDataset)
     assert result.SOPInstanceUID == an_instance.INFORMATION['MainDicomTags']['SOPInstanceUID']
+
+
+@pytest.mark.parametrize('return_raw_response', [True, False])
+def test_ensure_non_raw_response(client, return_raw_response):
+    client.return_raw_response = return_raw_response
+
+    client = util.ensure_non_raw_response(client)
+
+    assert client.return_raw_response


### PR DESCRIPTION
- Classes and functions that use the client will make a copy of the client with raw_response = False

Related to #38 