### PR TITLE
Add easy access to parent rescources and shared-tags

### DIFF
--- a/pyorthanc/_resources/instance.py
+++ b/pyorthanc/_resources/instance.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, TYPE_CHECKING
 
 import pydicom
 
 from .resource import Resource
 from .. import errors, util
+
+if TYPE_CHECKING:
+    from . import Patient, Study, Series
 
 
 class Instance(Resource):
@@ -93,7 +98,20 @@ class Instance(Resource):
     def series_identifier(self) -> str:
         """Get the parent series identifier"""
         return self.get_main_information()['ParentSeries']
-    
+
+    @property
+    def parent_series(self) -> Series:
+        from . import Series
+        return Series(self.series_identifier, self.client)
+
+    @property
+    def parent_study(self) -> Study:
+        return self.parent_series.parent_study
+
+    @property
+    def parent_patient(self) -> Patient:
+        return self.parent_study.parent_patient
+
     @property
     def acquisition_number(self) -> int:
         return int(self._get_main_dicom_tag_value('AcquisitionNumber'))

--- a/pyorthanc/_resources/patient.py
+++ b/pyorthanc/_resources/patient.py
@@ -125,14 +125,7 @@ class Patient(Resource):
         Dict
             DICOM Patient module.
         """
-        if simplify and not short:
-            params = {'simplify': True}
-        elif short and not simplify:
-            params = {'short': True}
-        elif simplify and short:
-            raise ValueError('simplify and short can\'t be both True')
-        else:
-            params = {}
+        params = self._make_response_format_params(simplify, short)
 
         return dict(self.client.get_patients_id_module(
             self.id_,
@@ -574,14 +567,7 @@ class Patient(Resource):
 
     def get_shared_tags(self, simplify: bool = False, short: bool = False) -> Dict:
         """Retrieve the shared tags of the patient"""
-        if simplify and not short:
-            params = {'simplify': True}
-        elif short and not simplify:
-            params = {'short': True}
-        elif simplify and short:
-            raise ValueError('simplify and short can\'t be both True.')
-        else:
-            params = {}
+        params = self._make_response_format_params(simplify, short)
 
         return dict(self.client.get_patients_id_shared_tags(
             self.id_,

--- a/pyorthanc/_resources/patient.py
+++ b/pyorthanc/_resources/patient.py
@@ -572,6 +572,26 @@ class Patient(Resource):
 
         return Job(job_info['ID'], self.client)
 
+    def get_shared_tags(self, simplify: bool = False, short: bool = False) -> Dict:
+        """Retrieve the shared tags of the patient"""
+        if simplify and not short:
+            params = {'simplify': True}
+        elif short and not simplify:
+            params = {'short': True}
+        elif simplify and short:
+            raise ValueError('simplify and short can\'t be both True.')
+        else:
+            params = {}
+
+        return dict(self.client.get_patients_id_shared_tags(
+            self.id_,
+            params=params
+        ))
+
+    @property
+    def shared_tags(self) -> Dict:
+        return self.get_shared_tags(simplify=True)
+
     def remove_empty_studies(self) -> None:
         """Delete empty studies."""
         if self._child_resources is None:

--- a/pyorthanc/_resources/resource.py
+++ b/pyorthanc/_resources/resource.py
@@ -50,6 +50,18 @@ class Resource:
         except KeyError:
             raise errors.TagDoesNotExistError(f'{self} has no {tag} tag.')
 
+    def _make_response_format_params(self, simplify: bool = False, short: bool = False) -> Dict:
+        if simplify and not short:
+            params = {'simplify': True}
+        elif short and not simplify:
+            params = {'short': True}
+        elif simplify and short:
+            raise ValueError('simplify and short can\'t be both True.')
+        else:
+            params = {}
+
+        return params
+
     def __eq__(self, other: 'Resource') -> bool:
         return self.id_ == other.id_
 

--- a/pyorthanc/_resources/series.py
+++ b/pyorthanc/_resources/series.py
@@ -556,6 +556,26 @@ class Series(Resource):
         """
         return self.client.get_series_id_archive(self.id_)
 
+    def get_shared_tags(self, simplify: bool = False, short: bool = False) -> Dict:
+        """Retrieve the shared tags of the series"""
+        if simplify and not short:
+            params = {'simplify': True}
+        elif short and not simplify:
+            params = {'short': True}
+        elif simplify and short:
+            raise ValueError('simplify and short can\'t be both True.')
+        else:
+            params = {}
+
+        return dict(self.client.get_series_id_shared_tags(
+            self.id_,
+            params=params
+        ))
+
+    @property
+    def shared_tags(self) -> Dict:
+        return self.get_shared_tags(simplify=True)
+
     def remove_empty_instances(self) -> None:
         if self._child_resources is not None:
             self._child_resources = [i for i in self._child_resources if i is not None]

--- a/pyorthanc/_resources/series.py
+++ b/pyorthanc/_resources/series.py
@@ -572,14 +572,7 @@ class Series(Resource):
 
     def get_shared_tags(self, simplify: bool = False, short: bool = False) -> Dict:
         """Retrieve the shared tags of the series"""
-        if simplify and not short:
-            params = {'simplify': True}
-        elif short and not simplify:
-            params = {'short': True}
-        elif simplify and short:
-            raise ValueError('simplify and short can\'t be both True.')
-        else:
-            params = {}
+        params = self._make_response_format_params(simplify, short)
 
         return dict(self.client.get_series_id_shared_tags(
             self.id_,

--- a/pyorthanc/_resources/series.py
+++ b/pyorthanc/_resources/series.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from datetime import datetime
-from typing import Dict, List
+from typing import Dict, List, TYPE_CHECKING
 
 from httpx import ReadTimeout
 
@@ -7,6 +9,9 @@ from .instance import Instance
 from .resource import Resource
 from .. import errors, util
 from ..jobs import Job
+
+if TYPE_CHECKING:
+    from . import Patient, Study
 
 
 class Series(Resource):
@@ -55,6 +60,15 @@ class Series(Resource):
     def study_identifier(self) -> str:
         """Get the parent study identifier"""
         return self.get_main_information()['ParentStudy']
+
+    @property
+    def parent_study(self) -> Study:
+        from . import Study
+        return Study(self.study_identifier, self.client)
+
+    @property
+    def parent_patient(self) -> Patient:
+        return self.parent_study.parent_patient
 
     @property
     def date(self) -> datetime:

--- a/pyorthanc/_resources/study.py
+++ b/pyorthanc/_resources/study.py
@@ -518,6 +518,26 @@ class Study(Resource):
         """
         return self.client.get_studies_id_archive(self.id_)
 
+    def get_shared_tags(self, simplify: bool = False, short: bool = False) -> Dict:
+        """Retrieve the shared tags of the study"""
+        if simplify and not short:
+            params = {'simplify': True}
+        elif short and not simplify:
+            params = {'short': True}
+        elif simplify and short:
+            raise ValueError('simplify and short can\'t be both True.')
+        else:
+            params = {}
+
+        return dict(self.client.get_studies_id_shared_tags(
+            self.id_,
+            params=params
+        ))
+
+    @property
+    def shared_tags(self) -> Dict:
+        return self.get_shared_tags(simplify=True)
+
     def remove_empty_series(self) -> None:
         """Delete empty series."""
         if self._child_resources is None:

--- a/pyorthanc/_resources/study.py
+++ b/pyorthanc/_resources/study.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from datetime import datetime
-from typing import Dict, List
+from typing import Dict, List, TYPE_CHECKING
 
 from httpx import ReadTimeout
 
@@ -7,6 +9,9 @@ from .resource import Resource
 from .series import Series
 from .. import errors, util
 from ..jobs import Job
+
+if TYPE_CHECKING:
+    from . import Patient
 
 
 class Study(Resource):
@@ -76,6 +81,11 @@ class Study(Resource):
     def patient_identifier(self) -> str:
         """Get the Orthanc identifier of the parent patient"""
         return self.get_main_information()['ParentPatient']
+
+    @property
+    def parent_patient(self) -> Patient:
+        from . import Patient
+        return Patient(self.patient_identifier, self.client)
 
     @property
     def patient_information(self) -> Dict:

--- a/pyorthanc/_resources/study.py
+++ b/pyorthanc/_resources/study.py
@@ -530,14 +530,7 @@ class Study(Resource):
 
     def get_shared_tags(self, simplify: bool = False, short: bool = False) -> Dict:
         """Retrieve the shared tags of the study"""
-        if simplify and not short:
-            params = {'simplify': True}
-        elif short and not simplify:
-            params = {'short': True}
-        elif simplify and short:
-            raise ValueError('simplify and short can\'t be both True.')
-        else:
-            params = {}
+        params = self._make_response_format_params(simplify, short)
 
         return dict(self.client.get_studies_id_shared_tags(
             self.id_,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyorthanc"
-version = "1.14.1"
+version = "1.15.0"
 description = "Orthanc REST API python wrapper with additional utilities"
 authors = [
     "Gabriel Couture <gacou54@gmail.com>",

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -3,9 +3,9 @@ from datetime import datetime
 import pydicom
 import pytest
 
-from pyorthanc import errors
+from pyorthanc import Patient, Series, Study, errors
 from .conftest import LABEL_INSTANCE
-from .data import a_series, an_instance
+from .data import a_patient, a_series, a_study, an_instance
 
 EXPECTED_DATE = datetime(
     year=2010,
@@ -29,6 +29,13 @@ def test_attributes(instance):
     assert instance.image_position_patient == [-223.9880065918, -158.08148193359, -117.78499603271]
     assert instance.instance_number == int(an_instance.INFORMATION['MainDicomTags']['InstanceNumber'])
     assert instance.number_of_frames == 75
+
+    assert isinstance(instance.parent_series, Series)
+    assert instance.parent_series.modality == a_series.MODALITY
+    assert isinstance(instance.parent_study, Study)
+    assert instance.parent_study.date == a_study.DATE
+    assert isinstance(instance.parent_patient, Patient)
+    assert instance.parent_patient.name == a_patient.NAME
 
     assert '0008,0012' in instance.tags.keys()
     assert 'Value' in instance.tags['0008,0012'].keys()

--- a/tests/test_modality.py
+++ b/tests/test_modality.py
@@ -49,10 +49,10 @@ def test_query(modality):
 
 
 def test_failed_query(modality):
-    BAD_PAYLOAD = {'Level': 'Study', 'Query': {'BadTag': 'MP*'}}
+    bad_payload = {'Level': 'Study', 'Query': {'BadTag': 'MP*'}}
 
     with pytest.raises(httpx.HTTPError):
-        modality.query(BAD_PAYLOAD)
+        modality.query(bad_payload)
 
 
 def test_move(modality):

--- a/tests/test_patient.py
+++ b/tests/test_patient.py
@@ -25,6 +25,12 @@ def test_attributes(patient):
     assert isinstance(patient.last_update, datetime)
     assert str(patient) == f'Patient({a_patient.IDENTIFIER})'
 
+    shared_tags = patient.shared_tags
+    assert isinstance(shared_tags, dict)
+    assert 'PatientName' in shared_tags  # simply checking for common shared tags
+    assert 'PatientBirthDate' in shared_tags
+
+
     assert [s.identifier for s in patient.studies] == a_patient.INFORMATION['Studies']
 
 

--- a/tests/test_patient.py
+++ b/tests/test_patient.py
@@ -30,14 +30,13 @@ def test_attributes(patient):
     assert 'PatientName' in shared_tags  # simply checking for common shared tags
     assert 'PatientBirthDate' in shared_tags
 
-
     assert [s.identifier for s in patient.studies] == a_patient.INFORMATION['Studies']
 
 
 def test_zip(patient):
     result = patient.get_zip()
 
-    assert type(result) == bytes
+    assert type(result) is bytes
     zipfile = ZipFile(io.BytesIO(result))
     assert zipfile.testzip() is None  # Verify that zip files are valid (if it is, returns None)
 

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -22,6 +22,11 @@ def test_attributes(series):
     assert series.station_name == a_series.INFORMATION['MainDicomTags']['StationName']
     assert series.image_orientation_patient == [1, 0, 0, 0, 1, 0]
 
+    shared_tags = series.shared_tags
+    assert isinstance(shared_tags, dict)
+    assert 'PatientName' in shared_tags  # simply checking for common shared tags
+    assert 'PixelSpacing' in shared_tags
+
     assert series.labels == [LABEL_SERIES]
     assert not series.is_stable
     assert isinstance(series.last_update, datetime)
@@ -39,7 +44,7 @@ def test_attributes(series):
 def test_zip(series):
     result = series.get_zip()
 
-    assert type(result) == bytes
+    assert isinstance(result, bytes)
     zipfile = ZipFile(io.BytesIO(result))
     assert zipfile.testzip() is None  # Verify that zip files are valid (if it is, returns None)
 

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -5,9 +5,9 @@ from zipfile import ZipFile
 import httpx
 import pytest
 
-from pyorthanc import Series, Study, errors
+from pyorthanc import Patient, Series, Study, errors
 from .conftest import LABEL_SERIES
-from .data import a_series
+from .data import a_patient, a_series, a_study
 
 
 def test_attributes(series):
@@ -31,6 +31,11 @@ def test_attributes(series):
     assert not series.is_stable
     assert isinstance(series.last_update, datetime)
     assert str(series) == f'Series({a_series.IDENTIFIER})'
+
+    assert isinstance(series.parent_study, Study)
+    assert series.parent_study.date == a_study.DATE
+    assert isinstance(series.parent_patient, Patient)
+    assert series.parent_patient.name == a_patient.NAME
 
     for absent_attribute in ['performed_procedure_step_description', 'sequence_name',
                              'protocol_name', 'description', 'body_part_examined', 'cardiac_number_of_images',

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -26,6 +26,11 @@ def test_attributes(study):
     assert study.series != []
     assert str(study) == f'Study({a_study.IDENTIFIER})'
 
+    shared_tags = study.shared_tags
+    assert isinstance(shared_tags, dict)
+    assert 'PatientName' in shared_tags  # simply checking for common shared tags
+    assert 'StudyDate' in shared_tags
+
     for absent_attribute in ['description', 'institution_name', 'requested_procedure_description', 'requesting_physician']:
         with pytest.raises(errors.TagDoesNotExistError):
             getattr(study, absent_attribute)

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -5,9 +5,9 @@ from zipfile import ZipFile
 import httpx
 import pytest
 
-from pyorthanc import Study, errors, util
+from pyorthanc import Patient, Study, errors, util
 from .conftest import LABEL_STUDY
-from .data import a_study
+from .data import a_patient, a_study
 
 
 def test_attributes(study):
@@ -25,6 +25,9 @@ def test_attributes(study):
     assert isinstance(study.last_update, datetime)
     assert study.series != []
     assert str(study) == f'Study({a_study.IDENTIFIER})'
+
+    assert isinstance(study.parent_patient, Patient)
+    assert study.parent_patient.name == a_patient.NAME
 
     shared_tags = study.shared_tags
     assert isinstance(shared_tags, dict)


### PR DESCRIPTION
Features:
- Each resource as new `parent_(patient/study/series)` property that facilitate the access to its parent resources
- Patient, Study and Series objects now have a `shared_tags` property that retrieve the shared tags in a simplified format
  - For more control on the output format, a `get_shared_tags(simplify=True/False, short=True/False)` method is also accessible