### PR TITLE
MainDicomTags are only queried once

### DIFF
--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -134,8 +134,8 @@ The `pyorthanc.find()` function allow to find resources with filters on many lev
 or with complex filter. Each filter function takes an object that correspond to the resource level
 and should return a boolean value.
 
-Note that when using the `find()` function, the state of the resources `Patient/Study/Series/Instance` 
-are locked.
+Note that when using the `find()` function, the children of the resources `Patient/Study/Series/Instance`
+are only query once and then filtered accordingly to the provided filters.
 ```python
 from datetime import datetime
 from pyorthanc import find

--- a/pyorthanc/__init__.py
+++ b/pyorthanc/__init__.py
@@ -1,5 +1,5 @@
 from . import errors, util
-from ._filtering import build_patient_forest, find, trim_patients
+from ._filtering import find, trim_patients
 from ._find import find_instances, find_patients, find_series, find_studies, query_orthanc
 from ._modality import Modality, RemoteModality
 from ._resources import Instance, Patient, Series, Study
@@ -18,7 +18,6 @@ __all__ = [
     'Study',
     'Series',
     'Instance',
-    'build_patient_forest',
     'trim_patients',
     'find',
     'find_patients',

--- a/pyorthanc/_filtering.py
+++ b/pyorthanc/_filtering.py
@@ -55,7 +55,7 @@ def find(orthanc: Union[Orthanc, AsyncOrthanc],
             instance_filter=instance_filter
         ))
 
-    patients = [Patient(i, orthanc, lock=True) for i in orthanc.get_patients()]
+    patients = [Patient(i, orthanc, _lock_children=True) for i in orthanc.get_patients()]
     if patient_filter is not None:
         patients = [i for i in patients if patient_filter(i)]
 
@@ -109,7 +109,7 @@ async def _async_build_patient(
         study_filter: Optional[Callable],
         series_filter: Optional[Callable],
         instance_filter: Optional[Callable]) -> Patient:
-    patient = Patient(patient_id_, async_to_sync(async_orthanc), lock=True)
+    patient = Patient(patient_id_, async_to_sync(async_orthanc), _lock_children=True)
 
     if patient_filter is not None:
         if not patient_filter(patient):
@@ -136,7 +136,7 @@ async def _async_build_study(
         study_filter: Optional[Callable],
         series_filter: Optional[Callable],
         instance_filter: Optional[Callable]) -> Study:
-    study = Study(study_information['ID'], async_to_sync(async_orthanc), lock=True)
+    study = Study(study_information['ID'], async_to_sync(async_orthanc), _lock_children=True)
     study._information = study_information
 
     if study_filter is not None:
@@ -161,7 +161,7 @@ async def _async_build_series(
         async_orthanc: AsyncOrthanc,
         series_filter: Optional[Callable],
         instance_filter: Optional[Callable]) -> Series:
-    series = Series(series_information['ID'], async_to_sync(async_orthanc), lock=True)
+    series = Series(series_information['ID'], async_to_sync(async_orthanc), _lock_children=True)
     series._information = series_information
 
     if series_filter is not None:
@@ -181,7 +181,7 @@ def _build_instance(
         instance_information: Dict,
         orthanc: Orthanc,
         instance_filter: Optional[Callable]) -> Optional[Instance]:
-    instance = Instance(instance_information['ID'], orthanc, lock=True)
+    instance = Instance(instance_information['ID'], orthanc, _lock_children=True)
     instance._information = instance_information
 
     if instance_filter is not None:

--- a/pyorthanc/_filtering.py
+++ b/pyorthanc/_filtering.py
@@ -12,20 +12,6 @@ from .client import Orthanc
 from .util import async_to_sync
 
 
-def build_patient_forest(
-        orthanc: Orthanc,
-        patient_filter: Optional[Callable] = None,
-        study_filter: Optional[Callable] = None,
-        series_filter: Optional[Callable] = None) -> List[Patient]:
-    warnings.warn(
-        'Function "build_patient_forest" is deprecated and will be removed in a future release. '
-        'Please use "find" instead',
-        DeprecationWarning,
-        stacklevel=2
-    )
-    return find(orthanc, patient_filter, study_filter, series_filter)
-
-
 def find(orthanc: Union[Orthanc, AsyncOrthanc],
          patient_filter: Optional[Callable] = None,
          study_filter: Optional[Callable] = None,

--- a/pyorthanc/_resources/instance.py
+++ b/pyorthanc/_resources/instance.py
@@ -85,13 +85,6 @@ class Instance(Resource):
         Dict
             Dictionary with tags as key and information as value
         """
-        if self.lock:
-            if self._information is None:
-                # Setup self._information for the first time when study is lock
-                self._information = self.client.get_instances_id(self.id_)
-
-            return self._information
-
         return self.client.get_instances_id(self.id_)
 
     @property
@@ -119,8 +112,8 @@ class Instance(Resource):
         datetime
             Creation Date
         """
-        date_string = self.get_main_information()['MainDicomTags']['InstanceCreationDate']
-        time_string = self.get_main_information()['MainDicomTags']['InstanceCreationTime']
+        date_string = self._get_main_dicom_tag_value('InstanceCreationDate')
+        time_string = self._get_main_dicom_tag_value('InstanceCreationTime')
 
         return util.make_datetime_from_dicom_date(date_string, time_string)
 

--- a/tests/resources/test_patient.py
+++ b/tests/resources/test_patient.py
@@ -141,7 +141,6 @@ def test_modify_replace(patient):
 
 def test_modify_as_job_remove(patient):
     job = patient.modify_as_job(remove=['PatientName'])
-    assert patient.name == a_patient.NAME
 
     job.wait_until_completion()
     assert patient.patient_id == a_patient.ID
@@ -158,7 +157,6 @@ def test_modify_as_job_remove(patient):
 
 def test_modify_as_job_replace(patient: Patient):
     job = patient.modify_as_job(replace={'PatientName': 'NewName'})
-    assert patient.name == a_patient.NAME
 
     job.wait_until_completion()
     assert patient.patient_id == a_patient.ID

--- a/tests/resources/test_series.py
+++ b/tests/resources/test_series.py
@@ -177,7 +177,6 @@ def test_modify_as_job_remove(series: Series):
         keep=['SeriesInstanceUID'],
         force=True
     )
-    assert series.manufacturer == a_series.MANUFACTURER
     job.wait_until_completion()
     modified_series = Series(job.content['ID'], series.client)
     assert modified_series.id_ == series.id_   # Ensure that it is the same object (since SeriesInstanceUID has not changed)
@@ -222,7 +221,7 @@ def test_modify_as_job_replace(series: Series):
 
 
 def test_remote_empty_instances(series):
-    series.lock = True
+    series._lock_children = True
 
     # Putting an empty instance
     series._child_resources = [None]

--- a/tests/resources/test_study.py
+++ b/tests/resources/test_study.py
@@ -41,7 +41,7 @@ def test_attributes(study: Study):
 
 
 def test_remove_empty_series(study: Study):
-    study.lock = True
+    study._lock_children = True
 
     for series in study.series:
         series._child_resources = []
@@ -167,7 +167,6 @@ def test_modify_as_job_remove(study: Study):
         keep=['StudyInstanceUID'],
         force=True
     )
-    assert study.referring_physician_name == a_study.INFORMATION['MainDicomTags']['ReferringPhysicianName']
     job.wait_until_completion()
     modified_study = Study(job.content['ID'], study.client)
     assert modified_study.id_ == study.id_   # Ensure that it is the same object (since StudyInstanceUID has not changed)

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -128,15 +128,11 @@ def test_query_orthanc(client_with_data_and_labels, level, query, labels, labels
         limit=limit,
         since=since,
         retrieve_all_resources=retrieve_all_resources,
-        lock=lock
+        lock_children=lock
     )
 
     for resource in result:
         assert resource.id_ in expected
-        if lock:
-            assert isinstance(resource._information, dict)
-        else:
-            assert resource._information is None
 
 
 @pytest.mark.parametrize('level, labels_constraint', [


### PR DESCRIPTION
- MainDicomTags are only queried once
- Metadata of resources not in DICOM tags are never cached
  - related #63 
- Resource children are cached when `Resource(_lock_children=True)`
  - This is mainly used in the `find(...)` function
- Remove deprecated function `build_patient_forest()`