### PR TITLE
✨ Update client to follow Orthanc 12.5 (API version 26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ Note that recent PyOrthanc versions will likely support older Orthanc version.
 
 | PyOrthanc version | Generated from                                |
 |-------------------|-----------------------------------------------|
-| \>= 1.18.0        | Orthanc API 1.12.4 with Python Plugin 4.2     |
+| \>= 1.19.0        | Orthanc API 1.12.5 with Python Plugin 4.2     |
+| 1.18.0            | Orthanc API 1.12.4 with Python Plugin 4.2     |
 | 1.17.0            | Orthanc API 1.12.3 with Python Plugin 4.2     |
 | 1.13.2 to 1.16.1  | Orthanc API 1.12.1 with Python Plugin 4.1     |
 | 1.13.0, 1.13.1    | Orthanc API 1.12.1 with Python Plugin 4.0     |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
     depends_on:
       - orthanc2
   orthanc2:
-    image: orthancteam/orthanc:24.5.1
+    image: orthancteam/orthanc:24.12.0
   test:
     build:
       context: .

--- a/pyorthanc/async_client.py
+++ b/pyorthanc/async_client.py
@@ -15,7 +15,7 @@ from httpx._types import (
 class AsyncOrthanc(httpx.AsyncClient):
     """Orthanc API
 
-    version 1.12.4
+    version 1.12.5
     This is the full documentation of the [REST API](https://orthanc.uclouvain.be/book/users/rest.html) of Orthanc.<p>This reference is automatically generated from the source code of Orthanc. A [shorter cheat sheet](https://orthanc.uclouvain.be/book/users/rest-cheatsheet.html) is part of the Orthanc Book.<p>An earlier, manually crafted version from August 2019, is [still available](2019-08-orthanc-openapi.html), but is not up-to-date anymore ([source](https://groups.google.com/g/orthanc-users/c/NUiJTEICSl8/m/xKeqMrbqAAAJ)).
 
     """
@@ -45,7 +45,7 @@ class AsyncOrthanc(httpx.AsyncClient):
         """
         super().__init__(*args, **kwargs)
         self.url = url
-        self.version = "1.12.4"
+        self.version = "1.12.5"
         self.return_raw_response = return_raw_response
 
         if username and password:
@@ -277,15 +277,18 @@ class AsyncOrthanc(httpx.AsyncClient):
     ) -> Union[Dict, List, str, bytes, int, httpx.Response]:
         """(async) List changes
 
-        Whenever Orthanc receives a new DICOM instance, this event is recorded in the so-called _Changes Log_. This enables remote scripts to react to the arrival of new DICOM resources. A typical application is auto-routing, where an external script waits for a new DICOM instance to arrive into Orthanc, then forward this instance to another modality.
+        Whenever Orthanc receives a new DICOM instance, this event is recorded in the so-called _Changes Log_. This enables remote scripts to react to the arrival of new DICOM resources. A typical application is auto-routing, where an external script waits for a new DICOM instance to arrive into Orthanc, then forward this instance to another modality. Please note that, when resources are deleted, their corresponding change entries are also removed from the Changes Log, which helps ensuring that this log does not grow indefinitely.
         Tags: Tracking changes
 
         Parameters
         ----------
         params
             Dictionary of optional parameters:
+                "last" (float): Request only the last change id (this argument must be used alone)
                 "limit" (float): Limit the number of results
-                "since" (float): Show only the resources since the provided index
+                "since" (float): Show only the resources since the provided index excluded
+                "to" (float): Show only the resources till the provided index included (only available if your DB backend supports ExtendedChanges)
+                "type" (str): Show only the changes of the provided type (only available if your DB backend supports ExtendedChanges).  Multiple values can be provided and must be separated by a ';'.
 
         Returns
         -------
@@ -352,10 +355,11 @@ class AsyncOrthanc(httpx.AsyncClient):
         ----------
         params
             Dictionary of optional parameters:
-                "expand" (str): If present, retrieve detailed information about the individual instances
+                "expand" (str): If present, retrieve detailed information about the individual resources, not only their Orthanc identifiers
                 "full" (bool): If present, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
                 "limit" (float): Limit the number of results
-                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return
+                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return all Main Dicom Tags to keep backward compatibility with Orthanc prior to 1.11.0.
+                "response-content" (str): Defines the content of response for each returned resource.  Allowed values are `MainDicomTags`, `Metadata`, `Children`, `Parent`, `Labels`, `Status`, `IsStable`, `Attachments`.  If not specified, Orthanc will return `MainDicomTags`, `Metadata`, `Children`, `Parent`, `Labels`, `Status`, `IsStable`.e.g: 'response-content=MainDicomTags;Children (new in Orthanc 1.12.5 - overrides `expand`)
                 "short" (bool): If present, report the DICOM tags in hexadecimal format
                 "since" (float): Show only the resources since the provided index
 
@@ -427,7 +431,7 @@ class AsyncOrthanc(httpx.AsyncClient):
         params
             Dictionary of optional parameters:
                 "full" (bool): If present, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
-                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return
+                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return all Main Dicom Tags to keep backward compatibility with Orthanc prior to 1.11.0.
                 "short" (bool): If present, report the DICOM tags in hexadecimal format
 
         Returns
@@ -648,7 +652,8 @@ class AsyncOrthanc(httpx.AsyncClient):
             Orthanc identifier of the instance of interest
         headers
             Dictionary of optional headers:
-                "If-None-Match" (str): Optional revision of the metadata, to check if its content has changed
+                "Content-Range" (str): Optional content range to access part of the attachment (new in Orthanc 1.12.5)
+                "If-None-Match" (str): Optional revision of the attachment, to check if its content has changed
 
         Returns
         -------
@@ -741,7 +746,8 @@ class AsyncOrthanc(httpx.AsyncClient):
             Orthanc identifier of the instance of interest
         headers
             Dictionary of optional headers:
-                "If-None-Match" (str): Optional revision of the metadata, to check if its content has changed
+                "Content-Range" (str): Optional content range to access part of the attachment (new in Orthanc 1.12.5)
+                "If-None-Match" (str): Optional revision of the attachment, to check if its content has changed
 
         Returns
         -------
@@ -1871,7 +1877,7 @@ class AsyncOrthanc(httpx.AsyncClient):
         params
             Dictionary of optional parameters:
                 "full" (bool): If present, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
-                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return
+                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return all Main Dicom Tags to keep backward compatibility with Orthanc prior to 1.11.0.
                 "short" (bool): If present, report the DICOM tags in hexadecimal format
 
         Returns
@@ -1959,7 +1965,7 @@ class AsyncOrthanc(httpx.AsyncClient):
             Orthanc identifier of the instance of interest
         json
             Dictionary with the following keys:
-              "LimitToThisLevelMainDicomTags": Only reconstruct this level MainDicomTags by re-reading them from a random child instance of the resource. This option is much faster than a full reconstruct and is usefull e.g. if you have modified the 'ExtraMainDicomTags' at the Study level to optimize the speed of some C-Find. 'false' by default. (New in Orthanc 1.12.4)
+              "LimitToThisLevelMainDicomTags": Only reconstruct this level MainDicomTags by re-reading them from a random child instance of the resource. This option is much faster than a full reconstruct and is useful e.g. if you have modified the 'ExtraMainDicomTags' at the Study level to optimize the speed of some C-Find. 'false' by default. (New in Orthanc 1.12.4)
               "ReconstructFiles": Also reconstruct the files of the resources (e.g: apply IngestTranscoding, StorageCompression). 'false' by default. (New in Orthanc 1.11.0)
 
 
@@ -2032,7 +2038,7 @@ class AsyncOrthanc(httpx.AsyncClient):
         params
             Dictionary of optional parameters:
                 "full" (bool): If present, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
-                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return
+                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return all Main Dicom Tags to keep backward compatibility with Orthanc prior to 1.11.0.
                 "short" (bool): If present, report the DICOM tags in hexadecimal format
 
         Returns
@@ -2114,7 +2120,7 @@ class AsyncOrthanc(httpx.AsyncClient):
         params
             Dictionary of optional parameters:
                 "full" (bool): If present, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
-                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return
+                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return all Main Dicom Tags to keep backward compatibility with Orthanc prior to 1.11.0.
                 "short" (bool): If present, report the DICOM tags in hexadecimal format
 
         Returns
@@ -2747,7 +2753,7 @@ class AsyncOrthanc(httpx.AsyncClient):
               "Level": Level of the query (`Patient`, `Study`, `Series` or `Instance`)
               "LocalAet": Local AET that is used for this commands, defaults to `DicomAet` configuration option. Ignored if `DicomModalities` already sets `LocalAet` for this modality.
               "Permissive": If `true`, ignore errors during the individual steps of the job.
-              "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
               "Resources": List of queries identifying all the DICOM resources to be sent
               "Synchronous": If `true`, run the job in synchronous mode, which means that the HTTP answer will directly contain the result of the job. This is the default, easy behavior, but it is *not* desirable for long jobs, as it might lead to network timeouts.
               "TargetAet": Target AET that will be used by the remote DICOM modality as a target for its C-STORE SCU commands, defaults to `DicomAet` configuration option in order to do a simple query/retrieve
@@ -2859,7 +2865,7 @@ class AsyncOrthanc(httpx.AsyncClient):
               "MoveOriginatorID": Move originator ID that is used for this commands, in order to fake a C-MOVE SCU
               "Permissive": If `true`, ignore errors during the individual steps of the job.
               "Port": Port that is used for this command, defaults to `Port` configuration option. Allows you to overwrite the destination port for a specific operation.
-              "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
               "Resources": List of the Orthanc identifiers of all the DICOM resources to be sent
               "StorageCommitment": Whether to chain C-STORE with DICOM storage commitment to validate the success of the transmission: https://orthanc.uclouvain.be/book/users/storage-commitment.html#chaining-c-store-with-storage-commitment
               "Synchronous": If `true`, run the job in synchronous mode, which means that the HTTP answer will directly contain the result of the job. This is the default, easy behavior, but it is *not* desirable for long jobs, as it might lead to network timeouts.
@@ -2921,10 +2927,11 @@ class AsyncOrthanc(httpx.AsyncClient):
         ----------
         params
             Dictionary of optional parameters:
-                "expand" (str): If present, retrieve detailed information about the individual patients
+                "expand" (str): If present, retrieve detailed information about the individual resources, not only their Orthanc identifiers
                 "full" (bool): If present, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
                 "limit" (float): Limit the number of results
-                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return
+                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return all Main Dicom Tags to keep backward compatibility with Orthanc prior to 1.11.0.
+                "response-content" (str): Defines the content of response for each returned resource.  Allowed values are `MainDicomTags`, `Metadata`, `Children`, `Parent`, `Labels`, `Status`, `IsStable`, `Attachments`.  If not specified, Orthanc will return `MainDicomTags`, `Metadata`, `Children`, `Parent`, `Labels`, `Status`, `IsStable`.e.g: 'response-content=MainDicomTags;Children (new in Orthanc 1.12.5 - overrides `expand`)
                 "short" (bool): If present, report the DICOM tags in hexadecimal format
                 "since" (float): Show only the resources since the provided index
 
@@ -2977,7 +2984,7 @@ class AsyncOrthanc(httpx.AsyncClient):
         params
             Dictionary of optional parameters:
                 "full" (bool): If present, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
-                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return
+                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return all Main Dicom Tags to keep backward compatibility with Orthanc prior to 1.11.0.
                 "short" (bool): If present, report the DICOM tags in hexadecimal format
 
         Returns
@@ -3014,7 +3021,7 @@ class AsyncOrthanc(httpx.AsyncClient):
               "KeepPrivateTags": Keep the private tags from the DICOM instances (defaults to `false`)
               "KeepSource": If set to `false`, instructs Orthanc to the remove original resources. By default, the original resources are kept in Orthanc.
               "Permissive": If `true`, ignore errors during the individual steps of the job.
-              "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
               "PrivateCreator": The private creator to be used for private tags in `Replace`
               "Remove": List of additional tags to be removed from the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
               "Replace": Associative array to change the value of some DICOM tags in the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
@@ -3080,7 +3087,7 @@ class AsyncOrthanc(httpx.AsyncClient):
         json
             Dictionary with the following keys:
               "Asynchronous": If `true`, create the archive in asynchronous mode, which means that a job is submitted to create the archive in background.
-              "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
               "Synchronous": If `true`, create the archive in synchronous mode, which means that the HTTP answer will directly contain the ZIP file. This is the default, easy behavior. However, if global configuration option "SynchronousZipStream" is set to "false", asynchronous transfers should be preferred for large amount of data, as the creation of the temporary file might lead to network timeouts.
               "Transcode": If present, the DICOM files in the archive will be transcoded to the provided transfer syntax: https://orthanc.uclouvain.be/book/faq/transcoding.html
 
@@ -3266,7 +3273,8 @@ class AsyncOrthanc(httpx.AsyncClient):
             Orthanc identifier of the patient of interest
         headers
             Dictionary of optional headers:
-                "If-None-Match" (str): Optional revision of the metadata, to check if its content has changed
+                "Content-Range" (str): Optional content range to access part of the attachment (new in Orthanc 1.12.5)
+                "If-None-Match" (str): Optional revision of the attachment, to check if its content has changed
 
         Returns
         -------
@@ -3359,7 +3367,8 @@ class AsyncOrthanc(httpx.AsyncClient):
             Orthanc identifier of the patient of interest
         headers
             Dictionary of optional headers:
-                "If-None-Match" (str): Optional revision of the metadata, to check if its content has changed
+                "Content-Range" (str): Optional content range to access part of the attachment (new in Orthanc 1.12.5)
+                "If-None-Match" (str): Optional revision of the attachment, to check if its content has changed
 
         Returns
         -------
@@ -3564,7 +3573,7 @@ class AsyncOrthanc(httpx.AsyncClient):
             Dictionary of optional parameters:
                 "expand" (str): If false or missing, only retrieve the list of child instances
                 "full" (bool): If present, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
-                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return
+                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return all Main Dicom Tags to keep backward compatibility with Orthanc prior to 1.11.0.
                 "short" (bool): If present, report the DICOM tags in hexadecimal format
 
         Returns
@@ -3754,7 +3763,7 @@ class AsyncOrthanc(httpx.AsyncClient):
             Dictionary with the following keys:
               "Asynchronous": If `true`, create the archive in asynchronous mode, which means that a job is submitted to create the archive in background.
               "Extended": If `true`, will include additional tags such as `SeriesDescription`, leading to a so-called *extended DICOMDIR*. Default value is `false`.
-              "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
               "Synchronous": If `true`, create the archive in synchronous mode, which means that the HTTP answer will directly contain the ZIP file. This is the default, easy behavior. However, if global configuration option "SynchronousZipStream" is set to "false", asynchronous transfers should be preferred for large amount of data, as the creation of the temporary file might lead to network timeouts.
               "Transcode": If present, the DICOM files in the archive will be transcoded to the provided transfer syntax: https://orthanc.uclouvain.be/book/faq/transcoding.html
 
@@ -3917,7 +3926,7 @@ class AsyncOrthanc(httpx.AsyncClient):
               "Keep": Keep the original value of the specified tags, to be chosen among the `StudyInstanceUID`, `SeriesInstanceUID` and `SOPInstanceUID` tags. Avoid this feature as much as possible, as this breaks the DICOM model of the real world.
               "KeepSource": If set to `false`, instructs Orthanc to the remove original resources. By default, the original resources are kept in Orthanc.
               "Permissive": If `true`, ignore errors during the individual steps of the job.
-              "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
               "PrivateCreator": The private creator to be used for private tags in `Replace`
               "Remove": List of tags that must be removed from the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
               "RemovePrivateTags": Remove the private tags from the DICOM instances (defaults to `false`)
@@ -4029,7 +4038,7 @@ class AsyncOrthanc(httpx.AsyncClient):
             Orthanc identifier of the patient of interest
         json
             Dictionary with the following keys:
-              "LimitToThisLevelMainDicomTags": Only reconstruct this level MainDicomTags by re-reading them from a random child instance of the resource. This option is much faster than a full reconstruct and is usefull e.g. if you have modified the 'ExtraMainDicomTags' at the Study level to optimize the speed of some C-Find. 'false' by default. (New in Orthanc 1.12.4)
+              "LimitToThisLevelMainDicomTags": Only reconstruct this level MainDicomTags by re-reading them from a random child instance of the resource. This option is much faster than a full reconstruct and is useful e.g. if you have modified the 'ExtraMainDicomTags' at the Study level to optimize the speed of some C-Find. 'false' by default. (New in Orthanc 1.12.4)
               "ReconstructFiles": Also reconstruct the files of the resources (e.g: apply IngestTranscoding, StorageCompression). 'false' by default. (New in Orthanc 1.11.0)
 
 
@@ -4062,7 +4071,7 @@ class AsyncOrthanc(httpx.AsyncClient):
             Dictionary of optional parameters:
                 "expand" (str): If false or missing, only retrieve the list of child series
                 "full" (bool): If present, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
-                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return
+                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return all Main Dicom Tags to keep backward compatibility with Orthanc prior to 1.11.0.
                 "short" (bool): If present, report the DICOM tags in hexadecimal format
 
         Returns
@@ -4145,7 +4154,7 @@ class AsyncOrthanc(httpx.AsyncClient):
             Dictionary of optional parameters:
                 "expand" (str): If false or missing, only retrieve the list of child studies
                 "full" (bool): If present, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
-                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return
+                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return all Main Dicom Tags to keep backward compatibility with Orthanc prior to 1.11.0.
                 "short" (bool): If present, report the DICOM tags in hexadecimal format
 
         Returns
@@ -4307,7 +4316,7 @@ class AsyncOrthanc(httpx.AsyncClient):
               "Asynchronous": If `true`, run the job in asynchronous mode, which means that the REST API call will immediately return, reporting the identifier of a job. Prefer this flavor wherever possible.
               "Compress": Whether to compress the DICOM instances using gzip before the actual sending
               "Permissive": If `true`, ignore errors during the individual steps of the job.
-              "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
               "Resources": List of the Orthanc identifiers of all the DICOM resources to be sent
               "Synchronous": If `true`, run the job in synchronous mode, which means that the HTTP answer will directly contain the result of the job. This is the default, easy behavior, but it is *not* desirable for long jobs, as it might lead to network timeouts.
               "Transcode": Transcode to the provided DICOM transfer syntax before the actual sending
@@ -4713,7 +4722,7 @@ class AsyncOrthanc(httpx.AsyncClient):
               "Asynchronous": If `true`, run the job in asynchronous mode, which means that the REST API call will immediately return, reporting the identifier of a job. Prefer this flavor wherever possible.
               "Full": If set to `true`, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
               "Permissive": If `true`, ignore errors during the individual steps of the job.
-              "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
               "Simplify": If set to `true`, report the DICOM tags in human-readable format (using the symbolic name of the tags)
               "Synchronous": If `true`, run the job in synchronous mode, which means that the HTTP answer will directly contain the result of the job. This is the default, easy behavior, but it is *not* desirable for long jobs, as it might lead to network timeouts.
               "TargetAet": AET of the target modality. By default, the AET of Orthanc is used, as defined in the `DicomAet` configuration option.
@@ -4830,7 +4839,7 @@ class AsyncOrthanc(httpx.AsyncClient):
               "Asynchronous": If `true`, run the job in asynchronous mode, which means that the REST API call will immediately return, reporting the identifier of a job. Prefer this flavor wherever possible.
               "Full": If set to `true`, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
               "Permissive": If `true`, ignore errors during the individual steps of the job.
-              "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
               "Simplify": If set to `true`, report the DICOM tags in human-readable format (using the symbolic name of the tags)
               "Synchronous": If `true`, run the job in synchronous mode, which means that the HTTP answer will directly contain the result of the job. This is the default, easy behavior, but it is *not* desirable for long jobs, as it might lead to network timeouts.
               "TargetAet": AET of the target modality. By default, the AET of Orthanc is used, as defined in the `DicomAet` configuration option.
@@ -4865,10 +4874,11 @@ class AsyncOrthanc(httpx.AsyncClient):
         ----------
         params
             Dictionary of optional parameters:
-                "expand" (str): If present, retrieve detailed information about the individual series
+                "expand" (str): If present, retrieve detailed information about the individual resources, not only their Orthanc identifiers
                 "full" (bool): If present, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
                 "limit" (float): Limit the number of results
-                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return
+                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return all Main Dicom Tags to keep backward compatibility with Orthanc prior to 1.11.0.
+                "response-content" (str): Defines the content of response for each returned resource.  Allowed values are `MainDicomTags`, `Metadata`, `Children`, `Parent`, `Labels`, `Status`, `IsStable`, `Attachments`.  If not specified, Orthanc will return `MainDicomTags`, `Metadata`, `Children`, `Parent`, `Labels`, `Status`, `IsStable`.e.g: 'response-content=MainDicomTags;Children (new in Orthanc 1.12.5 - overrides `expand`)
                 "short" (bool): If present, report the DICOM tags in hexadecimal format
                 "since" (float): Show only the resources since the provided index
 
@@ -4921,7 +4931,7 @@ class AsyncOrthanc(httpx.AsyncClient):
         params
             Dictionary of optional parameters:
                 "full" (bool): If present, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
-                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return
+                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return all Main Dicom Tags to keep backward compatibility with Orthanc prior to 1.11.0.
                 "short" (bool): If present, report the DICOM tags in hexadecimal format
 
         Returns
@@ -4958,7 +4968,7 @@ class AsyncOrthanc(httpx.AsyncClient):
               "KeepPrivateTags": Keep the private tags from the DICOM instances (defaults to `false`)
               "KeepSource": If set to `false`, instructs Orthanc to the remove original resources. By default, the original resources are kept in Orthanc.
               "Permissive": If `true`, ignore errors during the individual steps of the job.
-              "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
               "PrivateCreator": The private creator to be used for private tags in `Replace`
               "Remove": List of additional tags to be removed from the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
               "Replace": Associative array to change the value of some DICOM tags in the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
@@ -5024,7 +5034,7 @@ class AsyncOrthanc(httpx.AsyncClient):
         json
             Dictionary with the following keys:
               "Asynchronous": If `true`, create the archive in asynchronous mode, which means that a job is submitted to create the archive in background.
-              "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
               "Synchronous": If `true`, create the archive in synchronous mode, which means that the HTTP answer will directly contain the ZIP file. This is the default, easy behavior. However, if global configuration option "SynchronousZipStream" is set to "false", asynchronous transfers should be preferred for large amount of data, as the creation of the temporary file might lead to network timeouts.
               "Transcode": If present, the DICOM files in the archive will be transcoded to the provided transfer syntax: https://orthanc.uclouvain.be/book/faq/transcoding.html
 
@@ -5210,7 +5220,8 @@ class AsyncOrthanc(httpx.AsyncClient):
             Orthanc identifier of the series of interest
         headers
             Dictionary of optional headers:
-                "If-None-Match" (str): Optional revision of the metadata, to check if its content has changed
+                "Content-Range" (str): Optional content range to access part of the attachment (new in Orthanc 1.12.5)
+                "If-None-Match" (str): Optional revision of the attachment, to check if its content has changed
 
         Returns
         -------
@@ -5303,7 +5314,8 @@ class AsyncOrthanc(httpx.AsyncClient):
             Orthanc identifier of the series of interest
         headers
             Dictionary of optional headers:
-                "If-None-Match" (str): Optional revision of the metadata, to check if its content has changed
+                "Content-Range" (str): Optional content range to access part of the attachment (new in Orthanc 1.12.5)
+                "If-None-Match" (str): Optional revision of the attachment, to check if its content has changed
 
         Returns
         -------
@@ -5508,7 +5520,7 @@ class AsyncOrthanc(httpx.AsyncClient):
             Dictionary of optional parameters:
                 "expand" (str): If false or missing, only retrieve the list of child instances
                 "full" (bool): If present, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
-                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return
+                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return all Main Dicom Tags to keep backward compatibility with Orthanc prior to 1.11.0.
                 "short" (bool): If present, report the DICOM tags in hexadecimal format
 
         Returns
@@ -5698,7 +5710,7 @@ class AsyncOrthanc(httpx.AsyncClient):
             Dictionary with the following keys:
               "Asynchronous": If `true`, create the archive in asynchronous mode, which means that a job is submitted to create the archive in background.
               "Extended": If `true`, will include additional tags such as `SeriesDescription`, leading to a so-called *extended DICOMDIR*. Default value is `false`.
-              "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
               "Synchronous": If `true`, create the archive in synchronous mode, which means that the HTTP answer will directly contain the ZIP file. This is the default, easy behavior. However, if global configuration option "SynchronousZipStream" is set to "false", asynchronous transfers should be preferred for large amount of data, as the creation of the temporary file might lead to network timeouts.
               "Transcode": If present, the DICOM files in the archive will be transcoded to the provided transfer syntax: https://orthanc.uclouvain.be/book/faq/transcoding.html
 
@@ -5861,7 +5873,7 @@ class AsyncOrthanc(httpx.AsyncClient):
               "Keep": Keep the original value of the specified tags, to be chosen among the `StudyInstanceUID`, `SeriesInstanceUID` and `SOPInstanceUID` tags. Avoid this feature as much as possible, as this breaks the DICOM model of the real world.
               "KeepSource": If set to `false`, instructs Orthanc to the remove original resources. By default, the original resources are kept in Orthanc.
               "Permissive": If `true`, ignore errors during the individual steps of the job.
-              "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
               "PrivateCreator": The private creator to be used for private tags in `Replace`
               "Remove": List of tags that must be removed from the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
               "RemovePrivateTags": Remove the private tags from the DICOM instances (defaults to `false`)
@@ -5982,7 +5994,7 @@ class AsyncOrthanc(httpx.AsyncClient):
         params
             Dictionary of optional parameters:
                 "full" (bool): If present, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
-                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return
+                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return all Main Dicom Tags to keep backward compatibility with Orthanc prior to 1.11.0.
                 "short" (bool): If present, report the DICOM tags in hexadecimal format
 
         Returns
@@ -6011,7 +6023,7 @@ class AsyncOrthanc(httpx.AsyncClient):
             Orthanc identifier of the series of interest
         json
             Dictionary with the following keys:
-              "LimitToThisLevelMainDicomTags": Only reconstruct this level MainDicomTags by re-reading them from a random child instance of the resource. This option is much faster than a full reconstruct and is usefull e.g. if you have modified the 'ExtraMainDicomTags' at the Study level to optimize the speed of some C-Find. 'false' by default. (New in Orthanc 1.12.4)
+              "LimitToThisLevelMainDicomTags": Only reconstruct this level MainDicomTags by re-reading them from a random child instance of the resource. This option is much faster than a full reconstruct and is useful e.g. if you have modified the 'ExtraMainDicomTags' at the Study level to optimize the speed of some C-Find. 'false' by default. (New in Orthanc 1.12.4)
               "ReconstructFiles": Also reconstruct the files of the resources (e.g: apply IngestTranscoding, StorageCompression). 'false' by default. (New in Orthanc 1.11.0)
 
 
@@ -6095,7 +6107,7 @@ class AsyncOrthanc(httpx.AsyncClient):
         params
             Dictionary of optional parameters:
                 "full" (bool): If present, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
-                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return
+                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return all Main Dicom Tags to keep backward compatibility with Orthanc prior to 1.11.0.
                 "short" (bool): If present, report the DICOM tags in hexadecimal format
 
         Returns
@@ -6183,10 +6195,11 @@ class AsyncOrthanc(httpx.AsyncClient):
         ----------
         params
             Dictionary of optional parameters:
-                "expand" (str): If present, retrieve detailed information about the individual studies
+                "expand" (str): If present, retrieve detailed information about the individual resources, not only their Orthanc identifiers
                 "full" (bool): If present, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
                 "limit" (float): Limit the number of results
-                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return
+                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return all Main Dicom Tags to keep backward compatibility with Orthanc prior to 1.11.0.
+                "response-content" (str): Defines the content of response for each returned resource.  Allowed values are `MainDicomTags`, `Metadata`, `Children`, `Parent`, `Labels`, `Status`, `IsStable`, `Attachments`.  If not specified, Orthanc will return `MainDicomTags`, `Metadata`, `Children`, `Parent`, `Labels`, `Status`, `IsStable`.e.g: 'response-content=MainDicomTags;Children (new in Orthanc 1.12.5 - overrides `expand`)
                 "short" (bool): If present, report the DICOM tags in hexadecimal format
                 "since" (float): Show only the resources since the provided index
 
@@ -6239,7 +6252,7 @@ class AsyncOrthanc(httpx.AsyncClient):
         params
             Dictionary of optional parameters:
                 "full" (bool): If present, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
-                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return
+                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return all Main Dicom Tags to keep backward compatibility with Orthanc prior to 1.11.0.
                 "short" (bool): If present, report the DICOM tags in hexadecimal format
 
         Returns
@@ -6276,7 +6289,7 @@ class AsyncOrthanc(httpx.AsyncClient):
               "KeepPrivateTags": Keep the private tags from the DICOM instances (defaults to `false`)
               "KeepSource": If set to `false`, instructs Orthanc to the remove original resources. By default, the original resources are kept in Orthanc.
               "Permissive": If `true`, ignore errors during the individual steps of the job.
-              "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
               "PrivateCreator": The private creator to be used for private tags in `Replace`
               "Remove": List of additional tags to be removed from the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
               "Replace": Associative array to change the value of some DICOM tags in the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
@@ -6342,7 +6355,7 @@ class AsyncOrthanc(httpx.AsyncClient):
         json
             Dictionary with the following keys:
               "Asynchronous": If `true`, create the archive in asynchronous mode, which means that a job is submitted to create the archive in background.
-              "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
               "Synchronous": If `true`, create the archive in synchronous mode, which means that the HTTP answer will directly contain the ZIP file. This is the default, easy behavior. However, if global configuration option "SynchronousZipStream" is set to "false", asynchronous transfers should be preferred for large amount of data, as the creation of the temporary file might lead to network timeouts.
               "Transcode": If present, the DICOM files in the archive will be transcoded to the provided transfer syntax: https://orthanc.uclouvain.be/book/faq/transcoding.html
 
@@ -6528,7 +6541,8 @@ class AsyncOrthanc(httpx.AsyncClient):
             Orthanc identifier of the study of interest
         headers
             Dictionary of optional headers:
-                "If-None-Match" (str): Optional revision of the metadata, to check if its content has changed
+                "Content-Range" (str): Optional content range to access part of the attachment (new in Orthanc 1.12.5)
+                "If-None-Match" (str): Optional revision of the attachment, to check if its content has changed
 
         Returns
         -------
@@ -6621,7 +6635,8 @@ class AsyncOrthanc(httpx.AsyncClient):
             Orthanc identifier of the study of interest
         headers
             Dictionary of optional headers:
-                "If-None-Match" (str): Optional revision of the metadata, to check if its content has changed
+                "Content-Range" (str): Optional content range to access part of the attachment (new in Orthanc 1.12.5)
+                "If-None-Match" (str): Optional revision of the attachment, to check if its content has changed
 
         Returns
         -------
@@ -6826,7 +6841,7 @@ class AsyncOrthanc(httpx.AsyncClient):
             Dictionary of optional parameters:
                 "expand" (str): If false or missing, only retrieve the list of child instances
                 "full" (bool): If present, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
-                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return
+                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return all Main Dicom Tags to keep backward compatibility with Orthanc prior to 1.11.0.
                 "short" (bool): If present, report the DICOM tags in hexadecimal format
 
         Returns
@@ -7016,7 +7031,7 @@ class AsyncOrthanc(httpx.AsyncClient):
             Dictionary with the following keys:
               "Asynchronous": If `true`, create the archive in asynchronous mode, which means that a job is submitted to create the archive in background.
               "Extended": If `true`, will include additional tags such as `SeriesDescription`, leading to a so-called *extended DICOMDIR*. Default value is `false`.
-              "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
               "Synchronous": If `true`, create the archive in synchronous mode, which means that the HTTP answer will directly contain the ZIP file. This is the default, easy behavior. However, if global configuration option "SynchronousZipStream" is set to "false", asynchronous transfers should be preferred for large amount of data, as the creation of the temporary file might lead to network timeouts.
               "Transcode": If present, the DICOM files in the archive will be transcoded to the provided transfer syntax: https://orthanc.uclouvain.be/book/faq/transcoding.html
 
@@ -7053,7 +7068,7 @@ class AsyncOrthanc(httpx.AsyncClient):
               "Asynchronous": If `true`, run the job in asynchronous mode, which means that the REST API call will immediately return, reporting the identifier of a job. Prefer this flavor wherever possible.
               "KeepSource": If set to `true`, instructs Orthanc to keep a copy of the original resources in their source study. By default, the original resources are deleted from Orthanc.
               "Permissive": If `true`, ignore errors during the individual steps of the job.
-              "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
               "Resources": The list of DICOM resources (studies, series, and/or instances) to be merged into the study of interest (mandatory option)
               "Synchronous": If `true`, run the job in synchronous mode, which means that the HTTP answer will directly contain the result of the job. This is the default, easy behavior, but it is *not* desirable for long jobs, as it might lead to network timeouts.
 
@@ -7215,7 +7230,7 @@ class AsyncOrthanc(httpx.AsyncClient):
               "Keep": Keep the original value of the specified tags, to be chosen among the `StudyInstanceUID`, `SeriesInstanceUID` and `SOPInstanceUID` tags. Avoid this feature as much as possible, as this breaks the DICOM model of the real world.
               "KeepSource": If set to `false`, instructs Orthanc to the remove original resources. By default, the original resources are kept in Orthanc.
               "Permissive": If `true`, ignore errors during the individual steps of the job.
-              "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
               "PrivateCreator": The private creator to be used for private tags in `Replace`
               "Remove": List of tags that must be removed from the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
               "RemovePrivateTags": Remove the private tags from the DICOM instances (defaults to `false`)
@@ -7313,7 +7328,7 @@ class AsyncOrthanc(httpx.AsyncClient):
         params
             Dictionary of optional parameters:
                 "full" (bool): If present, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
-                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return
+                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return all Main Dicom Tags to keep backward compatibility with Orthanc prior to 1.11.0.
                 "short" (bool): If present, report the DICOM tags in hexadecimal format
 
         Returns
@@ -7342,7 +7357,7 @@ class AsyncOrthanc(httpx.AsyncClient):
             Orthanc identifier of the study of interest
         json
             Dictionary with the following keys:
-              "LimitToThisLevelMainDicomTags": Only reconstruct this level MainDicomTags by re-reading them from a random child instance of the resource. This option is much faster than a full reconstruct and is usefull e.g. if you have modified the 'ExtraMainDicomTags' at the Study level to optimize the speed of some C-Find. 'false' by default. (New in Orthanc 1.12.4)
+              "LimitToThisLevelMainDicomTags": Only reconstruct this level MainDicomTags by re-reading them from a random child instance of the resource. This option is much faster than a full reconstruct and is useful e.g. if you have modified the 'ExtraMainDicomTags' at the Study level to optimize the speed of some C-Find. 'false' by default. (New in Orthanc 1.12.4)
               "ReconstructFiles": Also reconstruct the files of the resources (e.g: apply IngestTranscoding, StorageCompression). 'false' by default. (New in Orthanc 1.11.0)
 
 
@@ -7375,7 +7390,7 @@ class AsyncOrthanc(httpx.AsyncClient):
             Dictionary of optional parameters:
                 "expand" (str): If false or missing, only retrieve the list of child series
                 "full" (bool): If present, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
-                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return
+                "requested-tags" (str): If present, list the DICOM Tags you want to list in the response.  This argument is a semi-column separated list of DICOM Tags identifiers; e.g: 'requested-tags=0010,0010;PatientBirthDate'.  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return all Main Dicom Tags to keep backward compatibility with Orthanc prior to 1.11.0.
                 "short" (bool): If present, report the DICOM tags in hexadecimal format
 
         Returns
@@ -7438,7 +7453,7 @@ class AsyncOrthanc(httpx.AsyncClient):
               "KeepLabels": Keep the labels of all resources level (defaults to `false`)
               "KeepSource": If set to `true`, instructs Orthanc to keep a copy of the original series/instances in the source study. By default, the original series/instances are deleted from Orthanc.
               "Permissive": If `true`, ignore errors during the individual steps of the job.
-              "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
               "Remove": List of tags that must be removed in the new study (from the same modules as in the `Replace` option)
               "Replace": Associative array to change the value of some DICOM tags in the new study. These tags must be part of the "Patient Module Attributes" or the "General Study Module Attributes", as specified by the DICOM 2011 standard in Tables C.7-1 and C.7-3.
               "Series": The list of series to be separated from the parent study. These series must all be children of the same source study, that is specified in the URI.
@@ -7583,7 +7598,7 @@ class AsyncOrthanc(httpx.AsyncClient):
               "KeepPrivateTags": Keep the private tags from the DICOM instances (defaults to `false`)
               "KeepSource": If set to `false`, instructs Orthanc to the remove original resources. By default, the original resources are kept in Orthanc.
               "Permissive": If `true`, ignore errors during the individual steps of the job.
-              "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
               "PrivateCreator": The private creator to be used for private tags in `Replace`
               "Remove": List of additional tags to be removed from the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
               "Replace": Associative array to change the value of some DICOM tags in the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
@@ -7681,7 +7696,7 @@ class AsyncOrthanc(httpx.AsyncClient):
               "KeepSource": If set to `false`, instructs Orthanc to the remove original resources. By default, the original resources are kept in Orthanc.
               "Level": Level of the modification (`Patient`, `Study`, `Series` or `Instance`). If absent, the level defaults to `Instance`, but is set to `Patient` if `PatientID` is modified, to `Study` if `StudyInstanceUID` is modified, or to `Series` if `SeriesInstancesUID` is modified. (new in Orthanc 1.9.7)
               "Permissive": If `true`, ignore errors during the individual steps of the job.
-              "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
               "PrivateCreator": The private creator to be used for private tags in `Replace`
               "Remove": List of tags that must be removed from the DICOM instances. Starting with Orthanc 1.9.4, paths to subsequences can be provided using the same syntax as the `dcmodify` command-line tool (wildcards are supported as well).
               "RemovePrivateTags": Remove the private tags from the DICOM instances (defaults to `false`)
@@ -7700,6 +7715,43 @@ class AsyncOrthanc(httpx.AsyncClient):
             json = {}
         return await self._post(
             route=f"{self.url}/tools/bulk-modify",
+            json=json,
+        )
+
+    async def post_tools_count_resources(
+        self,
+        json: Any = None,
+    ) -> Union[Dict, List, str, bytes, int, httpx.Response]:
+        """(async) Count local resources
+
+        This URI can be used to count the resources that are matching criteria on the content of the local Orthanc server, in a way that is similar to tools/find
+        Tags: System
+
+        Parameters
+        ----------
+        json
+            Dictionary with the following keys:
+              "Full": If set to `true`, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
+              "Labels": List of strings specifying which labels to look for in the resources (new in Orthanc 1.12.0)
+              "LabelsConstraint": Constraint on the labels, can be `All`, `Any`, or `None` (defaults to `All`, new in Orthanc 1.12.0)
+              "Level": Level of the query (`Patient`, `Study`, `Series` or `Instance`)
+              "MetadataQuery": Associative array containing the filter on the values of the metadata (new in Orthanc 1.12.5)
+              "ParentPatient": Limit the reported resources to descendants of this patient (new in Orthanc 1.12.5)
+              "ParentSeries": Limit the reported resources to descendants of this series (new in Orthanc 1.12.5)
+              "ParentStudy": Limit the reported resources to descendants of this study (new in Orthanc 1.12.5)
+              "Query": Associative array containing the filter on the values of the DICOM tags
+              "Short": If set to `true`, report the DICOM tags in hexadecimal format
+
+
+        Returns
+        -------
+        Union[Dict, List, str, bytes, int, httpx.Response]
+            A JSON object with the `Count` of matching resources
+        """
+        if json is None:
+            json = {}
+        return await self._post(
+            route=f"{self.url}/tools/count-resources",
             json=json,
         )
 
@@ -7742,7 +7794,7 @@ class AsyncOrthanc(httpx.AsyncClient):
         json
             Dictionary with the following keys:
               "Asynchronous": If `true`, create the archive in asynchronous mode, which means that a job is submitted to create the archive in background.
-              "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
               "Resources": The list of Orthanc identifiers of interest.
               "Synchronous": If `true`, create the archive in synchronous mode, which means that the HTTP answer will directly contain the ZIP file. This is the default, easy behavior. However, if global configuration option "SynchronousZipStream" is set to "false", asynchronous transfers should be preferred for large amount of data, as the creation of the temporary file might lead to network timeouts.
               "Transcode": If present, the DICOM files in the archive will be transcoded to the provided transfer syntax: https://orthanc.uclouvain.be/book/faq/transcoding.html
@@ -7834,7 +7886,7 @@ class AsyncOrthanc(httpx.AsyncClient):
             Dictionary with the following keys:
               "Asynchronous": If `true`, create the archive in asynchronous mode, which means that a job is submitted to create the archive in background.
               "Extended": If `true`, will include additional tags such as `SeriesDescription`, leading to a so-called *extended DICOMDIR*. Default value is `false`.
-              "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
               "Resources": The list of Orthanc identifiers of interest.
               "Synchronous": If `true`, create the archive in synchronous mode, which means that the HTTP answer will directly contain the ZIP file. This is the default, easy behavior. However, if global configuration option "SynchronousZipStream" is set to "false", asynchronous transfers should be preferred for large amount of data, as the creation of the temporary file might lead to network timeouts.
               "Transcode": If present, the DICOM files in the archive will be transcoded to the provided transfer syntax: https://orthanc.uclouvain.be/book/faq/transcoding.html
@@ -7893,7 +7945,7 @@ class AsyncOrthanc(httpx.AsyncClient):
             Dictionary with the following keys:
               "Asynchronous": If `true`, create the archive in asynchronous mode, which means that a job is submitted to create the archive in background.
               "Extended": If `true`, will include additional tags such as `SeriesDescription`, leading to a so-called *extended DICOMDIR*. Default value is `true`.
-              "Priority": In asynchronous mode, the priority of the job. The lower the value, the higher the priority.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
               "Resources": The list of Orthanc identifiers of interest.
               "Synchronous": If `true`, create the archive in synchronous mode, which means that the HTTP answer will directly contain the ZIP file. This is the default, easy behavior. However, if global configuration option "SynchronousZipStream" is set to "false", asynchronous transfers should be preferred for large amount of data, as the creation of the temporary file might lead to network timeouts.
               "Transcode": If present, the DICOM files in the archive will be transcoded to the provided transfer syntax: https://orthanc.uclouvain.be/book/faq/transcoding.html
@@ -8041,14 +8093,20 @@ class AsyncOrthanc(httpx.AsyncClient):
         json
             Dictionary with the following keys:
               "CaseSensitive": Enable case-sensitive search for PN value representations (defaults to configuration option `CaseSensitivePN`)
-              "Expand": Also retrieve the content of the matching resources, not only their Orthanc identifiers
+              "Expand": If set to "true", retrieve detailed information about the individual resources, not only their Orthanc identifiers
               "Full": If set to `true`, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
               "Labels": List of strings specifying which labels to look for in the resources (new in Orthanc 1.12.0)
               "LabelsConstraint": Constraint on the labels, can be `All`, `Any`, or `None` (defaults to `All`, new in Orthanc 1.12.0)
               "Level": Level of the query (`Patient`, `Study`, `Series` or `Instance`)
               "Limit": Limit the number of reported resources
+              "MetadataQuery": Associative array containing the filter on the values of the metadata (new in Orthanc 1.12.5)
+              "OrderBy": Array of associative arrays containing the requested ordering (new in Orthanc 1.12.5)
+              "ParentPatient": Limit the reported resources to descendants of this patient (new in Orthanc 1.12.5)
+              "ParentSeries": Limit the reported resources to descendants of this series (new in Orthanc 1.12.5)
+              "ParentStudy": Limit the reported resources to descendants of this study (new in Orthanc 1.12.5)
               "Query": Associative array containing the filter on the values of the DICOM tags
               "RequestedTags": A list of DICOM tags to include in the response (applicable only if "Expand" is set to true).  The tags requested tags are returned in the 'RequestedTags' field in the response.  Note that, if you are requesting tags that are not listed in the Main Dicom Tags stored in DB, building the response might be slow since Orthanc will need to access the DICOM files.  If not specified, Orthanc will return all Main Dicom Tags to keep backward compatibility with Orthanc prior to 1.11.0.
+              "ResponseContent": Defines the content of response for each returned resource. (this field, if present, overrides the "Expand" field).  Allowed values are `MainDicomTags`, `Metadata`, `Children`, `Parent`, `Labels`, `Status`, `IsStable`, `Attachments`.  If not specified, Orthanc will return `MainDicomTags`, `Metadata`, `Children`, `Parent`, `Labels`, `Status`, `IsStable`.(new in Orthanc 1.12.5)
               "Short": If set to `true`, report the DICOM tags in hexadecimal format
               "Since": Show only the resources since the provided index (in conjunction with `Limit`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyorthanc"
-version = "1.18.0"
+version = "1.19.0"
 description = "Orthanc REST API python wrapper with additional utilities"
 authors = [
     "Gabriel Couture <gacou54@gmail.com>",

--- a/tests/client/test_patient_getters.py
+++ b/tests/client/test_patient_getters.py
@@ -100,8 +100,7 @@ def test_get_patient_series(client_with_data):
 
 
 def test_get_patient_series_when_no_data(client):
-    with pytest.raises(httpx.HTTPError):
-        client.get_patients_id_series(a_patient.IDENTIFIER)
+    assert client.get_patients_id_series(a_patient.IDENTIFIER) == []
 
 
 @pytest.mark.parametrize('params, expected_shared_tags', [

--- a/tests/client/test_study_getters.py
+++ b/tests/client/test_study_getters.py
@@ -61,8 +61,7 @@ def test_get_study_instances(client_with_data):
 
 
 def test_get_study_instances_when_no_data(client):
-    with pytest.raises(httpx.HTTPError):
-        client.get_studies_id_instances(a_study.IDENTIFIER)
+    assert client.get_studies_id_instances(a_study.IDENTIFIER) == []
 
 
 @pytest.mark.parametrize('params', [None, {'simplify': True}, {'short': True}])

--- a/tests/client/test_utils.py
+++ b/tests/client/test_utils.py
@@ -1,0 +1,53 @@
+def test_system(client):
+    result = client.get_system()
+
+    assert 'Version' in result
+    assert 'ApiVersion' in result
+    assert 'DicomAet' in result
+    assert 'DicomPort' in result
+    assert 'MainDicomTags' in result
+    assert 'Capabilities' in result
+
+
+def test_changes(client):
+    result = client.get_changes()
+
+    assert 'Changes' in result
+    assert 'Done' in result
+    assert 'Last' in result
+
+    result = client.get_changes(params={'type': 'StableStudy'})  # Example of type to filter on
+
+    assert 'Changes' in result
+    assert 'Done' in result
+    assert 'Last' in result
+
+
+def test_find(client_with_data_and_labels):
+    result = client_with_data_and_labels.post_tools_find(json={
+        'Level': 'Patient',
+        'Query': {'PatientID': '*'}
+    })
+    assert result == ['e34c28ce-981b0e5c-2a481559-cf0d5fbe-053335f8']
+
+    result = client_with_data_and_labels.post_tools_find(json={
+        'Level': 'Patient',
+        'Labels': ['UNKNOWN_LABEL'],
+        'Query': {'PatientID': '*'}
+    })
+    assert result == []
+
+
+def test_count_resources(client_with_data_and_labels):
+    result = client_with_data_and_labels.post_tools_count_resources(json={
+        'Level': 'Patient',
+        'Query': {'PatientID': '*'}
+    })
+    assert result['Count'] == 1
+
+    result = client_with_data_and_labels.post_tools_count_resources(json={
+        'Level': 'Patient',
+        'Labels': ['UNKNOWN_LABEL'],
+        'Query': {'PatientID': '*'}
+    })
+    assert result['Count'] == 0

--- a/tests/orthanc/orthanc-for-test.Dockerfile
+++ b/tests/orthanc/orthanc-for-test.Dockerfile
@@ -1,4 +1,4 @@
-FROM orthancteam/orthanc:24.5.1
+FROM orthancteam/orthanc:24.12.0
 
 RUN pip install httpx pydicom  --break-system-packages
 

--- a/tests/orthanc/pytest.Dockerfile
+++ b/tests/orthanc/pytest.Dockerfile
@@ -7,7 +7,7 @@ RUN python -m pip install poetry
 
 # Installing project dependecies
 COPY ../../pyproject.toml .
-RUN poetry install --extras "all"
+RUN poetry install --extras "all" --no-root
 
 COPY ../.. /app
 


### PR DESCRIPTION
- Update client to follow Orthanc 12.5 (API version 26)
- Fix failing tests