### PR TITLE
✨ Support for Orthanc 1.12.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ Note that recent PyOrthanc versions will likely support older Orthanc version.
 
 | PyOrthanc version | Generated from                                |
 |-------------------|-----------------------------------------------|
-| \>= 1.19.0        | Orthanc API 1.12.5 with Python Plugin 4.2     |
+| \>= 1.20.0        | Orthanc API 1.12.6 with Python Plugin 4.2     |
+| 1.19.0, 1.19.1    | Orthanc API 1.12.5 with Python Plugin 4.2     |
 | 1.18.0            | Orthanc API 1.12.4 with Python Plugin 4.2     |
 | 1.17.0            | Orthanc API 1.12.3 with Python Plugin 4.2     |
 | 1.13.2 to 1.16.1  | Orthanc API 1.12.1 with Python Plugin 4.1     |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       - orthanc2
 
   orthanc2:
-    image: orthancteam/orthanc:24.12.0
+    image: orthancteam/orthanc:25.2.0
     environment:
         ORTHANC_JSON: |
           {

--- a/pyorthanc/_modality.py
+++ b/pyorthanc/_modality.py
@@ -62,8 +62,10 @@ class Modality:
         --------
         >>> modality = Modality(Orthanc('http://localhost:8042'), 'modality')
         >>> query_id = modality.get(
-        ...     data={'Level': 'Study',
-        ...           'Resources': {'StudyInstanceUID': '1.3.6.1.4.1.22213.2.6291.2.1'}
+        ...     data={
+        ...         'Level': 'Study',
+        ...         'Resources': {'StudyInstanceUID': '1.3.6.1.4.1.22213.2.6291.2.1'}
+        ...     }
         ... )
 
         """

--- a/pyorthanc/async_client.py
+++ b/pyorthanc/async_client.py
@@ -2750,10 +2750,10 @@ class AsyncOrthanc(httpx.AsyncClient):
         json
             Dictionary with the following keys:
               "Asynchronous": If `true`, run the job in asynchronous mode, which means that the REST API call will immediately return, reporting the identifier of a job. Prefer this flavor wherever possible.
+              "Level": Level of the query (`Patient`, `Study`, `Series` or `Instance`)
               "LocalAet": Local AET that is used for this commands, defaults to `DicomAet` configuration option. Ignored if `DicomModalities` already sets `LocalAet` for this modality.
               "Permissive": If `true`, ignore errors during the individual steps of the job.
               "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
-              "Query": A query object identifying all the DICOM resources to be retrieved
               "Resources": List of queries identifying all the DICOM resources to be sent.  Usage of wildcards is prohibited and the query shall only contain DICOM ID tags.  Additionally, you may provide SOPClassesInStudy to limit the scope of the DICOM negotiation to certain SOPClassUID or to present uncommon SOPClassUID during the DICOM negotation.  By default, Orhanc will propose the most 120 common SOPClassUIDs.
               "Synchronous": If `true`, run the job in synchronous mode, which means that the HTTP answer will directly contain the result of the job. This is the default, easy behavior, but it is *not* desirable for long jobs, as it might lead to network timeouts.
               "Timeout": Timeout for the C-GET command, in seconds

--- a/pyorthanc/async_client.py
+++ b/pyorthanc/async_client.py
@@ -15,7 +15,7 @@ from httpx._types import (
 class AsyncOrthanc(httpx.AsyncClient):
     """Orthanc API
 
-    version 1.12.5
+    version 1.12.6
     This is the full documentation of the [REST API](https://orthanc.uclouvain.be/book/users/rest.html) of Orthanc.<p>This reference is automatically generated from the source code of Orthanc. A [shorter cheat sheet](https://orthanc.uclouvain.be/book/users/rest-cheatsheet.html) is part of the Orthanc Book.<p>An earlier, manually crafted version from August 2019, is [still available](2019-08-orthanc-openapi.html), but is not up-to-date anymore ([source](https://groups.google.com/g/orthanc-users/c/NUiJTEICSl8/m/xKeqMrbqAAAJ)).
 
     """
@@ -45,7 +45,7 @@ class AsyncOrthanc(httpx.AsyncClient):
         """
         super().__init__(*args, **kwargs)
         self.url = url
-        self.version = "1.12.5"
+        self.version = "1.12.6"
         self.return_raw_response = return_raw_response
 
         if username and password:
@@ -2733,6 +2733,44 @@ class AsyncOrthanc(httpx.AsyncClient):
             json=json,
         )
 
+    async def post_modalities_id_get(
+        self,
+        id_: str,
+        json: Any = None,
+    ) -> Union[Dict, List, str, bytes, int, httpx.Response]:
+        """(async) Trigger C-GET SCU
+
+        Start a C-GET SCU command as a job, in order to retrieve DICOM resources from a remote DICOM modality whose identifier is provided in the URL:
+        Tags: Networking
+
+        Parameters
+        ----------
+        id_
+            Identifier of the modality of interest
+        json
+            Dictionary with the following keys:
+              "Asynchronous": If `true`, run the job in asynchronous mode, which means that the REST API call will immediately return, reporting the identifier of a job. Prefer this flavor wherever possible.
+              "LocalAet": Local AET that is used for this commands, defaults to `DicomAet` configuration option. Ignored if `DicomModalities` already sets `LocalAet` for this modality.
+              "Permissive": If `true`, ignore errors during the individual steps of the job.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
+              "Query": A query object identifying all the DICOM resources to be retrieved
+              "Resources": List of queries identifying all the DICOM resources to be sent.  Usage of wildcards is prohibited and the query shall only contain DICOM ID tags.  Additionally, you may provide SOPClassesInStudy to limit the scope of the DICOM negotiation to certain SOPClassUID or to present uncommon SOPClassUID during the DICOM negotation.  By default, Orhanc will propose the most 120 common SOPClassUIDs.
+              "Synchronous": If `true`, run the job in synchronous mode, which means that the HTTP answer will directly contain the result of the job. This is the default, easy behavior, but it is *not* desirable for long jobs, as it might lead to network timeouts.
+              "Timeout": Timeout for the C-GET command, in seconds
+
+
+        Returns
+        -------
+        Union[Dict, List, str, bytes, int, httpx.Response]
+
+        """
+        if json is None:
+            json = {}
+        return await self._post(
+            route=f"{self.url}/modalities/{id_}/get",
+            json=json,
+        )
+
     async def post_modalities_id_move(
         self,
         id_: str,
@@ -4706,9 +4744,9 @@ class AsyncOrthanc(httpx.AsyncClient):
         data: RequestData = None,
         json: Any = None,
     ) -> Union[Dict, List, str, bytes, int, httpx.Response]:
-        """(async) Retrieve one answer
+        """(async) Retrieve one answer with a C-MOVE or a C-GET SCU
 
-        Start a C-MOVE SCU command as a job, in order to retrieve one answer associated with the query/retrieve operation whose identifiers are provided in the URL: https://orthanc.uclouvain.be/book/users/rest.html#performing-retrieve-c-move
+        Start a C-MOVE or a C-GET SCU command as a job, in order to retrieve one answer associated with the query/retrieve operation whose identifiers are provided in the URL: https://orthanc.uclouvain.be/book/users/rest.html#performing-retrieve-c-move
         Tags: Networking
 
         Parameters
@@ -4723,6 +4761,7 @@ class AsyncOrthanc(httpx.AsyncClient):
               "Full": If set to `true`, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
               "Permissive": If `true`, ignore errors during the individual steps of the job.
               "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
+              "RetrieveMethod": Force usage of C-MOVE or C-GET to retrieve the resource.  If note defined in the payload, the retrieve method is defined in the DicomDefaultRetrieveMethod configuration or in DicomModalities->..->RetrieveMethod
               "Simplify": If set to `true`, report the DICOM tags in human-readable format (using the symbolic name of the tags)
               "Synchronous": If `true`, run the job in synchronous mode, which means that the HTTP answer will directly contain the result of the job. This is the default, easy behavior, but it is *not* desirable for long jobs, as it might lead to network timeouts.
               "TargetAet": AET of the target modality. By default, the AET of Orthanc is used, as defined in the `DicomAet` configuration option.
@@ -4825,7 +4864,7 @@ class AsyncOrthanc(httpx.AsyncClient):
         data: RequestData = None,
         json: Any = None,
     ) -> Union[Dict, List, str, bytes, int, httpx.Response]:
-        """(async) Retrieve all answers
+        """(async) Retrieve all answers with C-MOVE SCU
 
         Start a C-MOVE SCU command as a job, in order to retrieve all the answers associated with the query/retrieve operation whose identifier is provided in the URL: https://orthanc.uclouvain.be/book/users/rest.html#performing-retrieve-c-move
         Tags: Networking
@@ -4840,6 +4879,7 @@ class AsyncOrthanc(httpx.AsyncClient):
               "Full": If set to `true`, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
               "Permissive": If `true`, ignore errors during the individual steps of the job.
               "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
+              "RetrieveMethod": Force usage of C-MOVE or C-GET to retrieve the resource.  If note defined in the payload, the retrieve method is defined in the DicomDefaultRetrieveMethod configuration or in DicomModalities->..->RetrieveMethod
               "Simplify": If set to `true`, report the DICOM tags in human-readable format (using the symbolic name of the tags)
               "Synchronous": If `true`, run the job in synchronous mode, which means that the HTTP answer will directly contain the result of the job. This is the default, easy behavior, but it is *not* desirable for long jobs, as it might lead to network timeouts.
               "TargetAet": AET of the target modality. By default, the AET of Orthanc is used, as defined in the `DicomAet` configuration option.
@@ -7527,6 +7567,23 @@ class AsyncOrthanc(httpx.AsyncClient):
         """
         return await self._get(
             route=f"{self.url}/tools",
+        )
+
+    async def get_tools_accepted_sop_classes(
+        self,
+    ) -> Union[Dict, List, str, bytes, int, httpx.Response]:
+        """(async) Get accepted SOPClassUID
+
+        Get the list of SOP Class UIDs that are accepted by Orthanc C-STORE SCP. This corresponds to the configuration options `AcceptedSopClasses` and `RejectedSopClasses`.
+        Tags: System
+
+        Returns
+        -------
+        Union[Dict, List, str, bytes, int, httpx.Response]
+            JSON array containing the SOP Class UIDs
+        """
+        return await self._get(
+            route=f"{self.url}/tools/accepted-sop-classes",
         )
 
     async def get_tools_accepted_transfer_syntaxes(

--- a/pyorthanc/client.py
+++ b/pyorthanc/client.py
@@ -2746,10 +2746,10 @@ class Orthanc(httpx.Client):
         json
             Dictionary with the following keys:
               "Asynchronous": If `true`, run the job in asynchronous mode, which means that the REST API call will immediately return, reporting the identifier of a job. Prefer this flavor wherever possible.
+              "Level": Level of the query (`Patient`, `Study`, `Series` or `Instance`)
               "LocalAet": Local AET that is used for this commands, defaults to `DicomAet` configuration option. Ignored if `DicomModalities` already sets `LocalAet` for this modality.
               "Permissive": If `true`, ignore errors during the individual steps of the job.
               "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
-              "Query": A query object identifying all the DICOM resources to be retrieved
               "Resources": List of queries identifying all the DICOM resources to be sent.  Usage of wildcards is prohibited and the query shall only contain DICOM ID tags.  Additionally, you may provide SOPClassesInStudy to limit the scope of the DICOM negotiation to certain SOPClassUID or to present uncommon SOPClassUID during the DICOM negotation.  By default, Orhanc will propose the most 120 common SOPClassUIDs.
               "Synchronous": If `true`, run the job in synchronous mode, which means that the HTTP answer will directly contain the result of the job. This is the default, easy behavior, but it is *not* desirable for long jobs, as it might lead to network timeouts.
               "Timeout": Timeout for the C-GET command, in seconds

--- a/pyorthanc/client.py
+++ b/pyorthanc/client.py
@@ -15,7 +15,7 @@ from httpx._types import (
 class Orthanc(httpx.Client):
     """Orthanc API
 
-    version 1.12.5
+    version 1.12.6
     This is the full documentation of the [REST API](https://orthanc.uclouvain.be/book/users/rest.html) of Orthanc.<p>This reference is automatically generated from the source code of Orthanc. A [shorter cheat sheet](https://orthanc.uclouvain.be/book/users/rest-cheatsheet.html) is part of the Orthanc Book.<p>An earlier, manually crafted version from August 2019, is [still available](2019-08-orthanc-openapi.html), but is not up-to-date anymore ([source](https://groups.google.com/g/orthanc-users/c/NUiJTEICSl8/m/xKeqMrbqAAAJ)).
 
     """
@@ -45,7 +45,7 @@ class Orthanc(httpx.Client):
         """
         super().__init__(*args, **kwargs)
         self.url = url
-        self.version = "1.12.5"
+        self.version = "1.12.6"
         self.return_raw_response = return_raw_response
 
         if username and password:
@@ -2729,6 +2729,44 @@ class Orthanc(httpx.Client):
             json=json,
         )
 
+    def post_modalities_id_get(
+        self,
+        id_: str,
+        json: Any = None,
+    ) -> Union[Dict, List, str, bytes, int, httpx.Response]:
+        """Trigger C-GET SCU
+
+        Start a C-GET SCU command as a job, in order to retrieve DICOM resources from a remote DICOM modality whose identifier is provided in the URL:
+        Tags: Networking
+
+        Parameters
+        ----------
+        id_
+            Identifier of the modality of interest
+        json
+            Dictionary with the following keys:
+              "Asynchronous": If `true`, run the job in asynchronous mode, which means that the REST API call will immediately return, reporting the identifier of a job. Prefer this flavor wherever possible.
+              "LocalAet": Local AET that is used for this commands, defaults to `DicomAet` configuration option. Ignored if `DicomModalities` already sets `LocalAet` for this modality.
+              "Permissive": If `true`, ignore errors during the individual steps of the job.
+              "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
+              "Query": A query object identifying all the DICOM resources to be retrieved
+              "Resources": List of queries identifying all the DICOM resources to be sent.  Usage of wildcards is prohibited and the query shall only contain DICOM ID tags.  Additionally, you may provide SOPClassesInStudy to limit the scope of the DICOM negotiation to certain SOPClassUID or to present uncommon SOPClassUID during the DICOM negotation.  By default, Orhanc will propose the most 120 common SOPClassUIDs.
+              "Synchronous": If `true`, run the job in synchronous mode, which means that the HTTP answer will directly contain the result of the job. This is the default, easy behavior, but it is *not* desirable for long jobs, as it might lead to network timeouts.
+              "Timeout": Timeout for the C-GET command, in seconds
+
+
+        Returns
+        -------
+        Union[Dict, List, str, bytes, int, httpx.Response]
+
+        """
+        if json is None:
+            json = {}
+        return self._post(
+            route=f"{self.url}/modalities/{id_}/get",
+            json=json,
+        )
+
     def post_modalities_id_move(
         self,
         id_: str,
@@ -4702,9 +4740,9 @@ class Orthanc(httpx.Client):
         data: RequestData = None,
         json: Any = None,
     ) -> Union[Dict, List, str, bytes, int, httpx.Response]:
-        """Retrieve one answer
+        """Retrieve one answer with a C-MOVE or a C-GET SCU
 
-        Start a C-MOVE SCU command as a job, in order to retrieve one answer associated with the query/retrieve operation whose identifiers are provided in the URL: https://orthanc.uclouvain.be/book/users/rest.html#performing-retrieve-c-move
+        Start a C-MOVE or a C-GET SCU command as a job, in order to retrieve one answer associated with the query/retrieve operation whose identifiers are provided in the URL: https://orthanc.uclouvain.be/book/users/rest.html#performing-retrieve-c-move
         Tags: Networking
 
         Parameters
@@ -4719,6 +4757,7 @@ class Orthanc(httpx.Client):
               "Full": If set to `true`, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
               "Permissive": If `true`, ignore errors during the individual steps of the job.
               "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
+              "RetrieveMethod": Force usage of C-MOVE or C-GET to retrieve the resource.  If note defined in the payload, the retrieve method is defined in the DicomDefaultRetrieveMethod configuration or in DicomModalities->..->RetrieveMethod
               "Simplify": If set to `true`, report the DICOM tags in human-readable format (using the symbolic name of the tags)
               "Synchronous": If `true`, run the job in synchronous mode, which means that the HTTP answer will directly contain the result of the job. This is the default, easy behavior, but it is *not* desirable for long jobs, as it might lead to network timeouts.
               "TargetAet": AET of the target modality. By default, the AET of Orthanc is used, as defined in the `DicomAet` configuration option.
@@ -4821,7 +4860,7 @@ class Orthanc(httpx.Client):
         data: RequestData = None,
         json: Any = None,
     ) -> Union[Dict, List, str, bytes, int, httpx.Response]:
-        """Retrieve all answers
+        """Retrieve all answers with C-MOVE SCU
 
         Start a C-MOVE SCU command as a job, in order to retrieve all the answers associated with the query/retrieve operation whose identifier is provided in the URL: https://orthanc.uclouvain.be/book/users/rest.html#performing-retrieve-c-move
         Tags: Networking
@@ -4836,6 +4875,7 @@ class Orthanc(httpx.Client):
               "Full": If set to `true`, report the DICOM tags in full format (tags indexed by their hexadecimal format, associated with their symbolic name and their value)
               "Permissive": If `true`, ignore errors during the individual steps of the job.
               "Priority": In asynchronous mode, the priority of the job. The higher the value, the higher the priority.
+              "RetrieveMethod": Force usage of C-MOVE or C-GET to retrieve the resource.  If note defined in the payload, the retrieve method is defined in the DicomDefaultRetrieveMethod configuration or in DicomModalities->..->RetrieveMethod
               "Simplify": If set to `true`, report the DICOM tags in human-readable format (using the symbolic name of the tags)
               "Synchronous": If `true`, run the job in synchronous mode, which means that the HTTP answer will directly contain the result of the job. This is the default, easy behavior, but it is *not* desirable for long jobs, as it might lead to network timeouts.
               "TargetAet": AET of the target modality. By default, the AET of Orthanc is used, as defined in the `DicomAet` configuration option.
@@ -7523,6 +7563,23 @@ class Orthanc(httpx.Client):
         """
         return self._get(
             route=f"{self.url}/tools",
+        )
+
+    def get_tools_accepted_sop_classes(
+        self,
+    ) -> Union[Dict, List, str, bytes, int, httpx.Response]:
+        """Get accepted SOPClassUID
+
+        Get the list of SOP Class UIDs that are accepted by Orthanc C-STORE SCP. This corresponds to the configuration options `AcceptedSopClasses` and `RejectedSopClasses`.
+        Tags: System
+
+        Returns
+        -------
+        Union[Dict, List, str, bytes, int, httpx.Response]
+            JSON array containing the SOP Class UIDs
+        """
+        return self._get(
+            route=f"{self.url}/tools/accepted-sop-classes",
         )
 
     def get_tools_accepted_transfer_syntaxes(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyorthanc"
-version = "1.19.1"
+version = "1.20.0"
 description = "Orthanc REST API python wrapper with additional utilities"
 authors = [
     "Gabriel Couture <gacou54@gmail.com>",

--- a/tests/orthanc/orthanc-for-test.Dockerfile
+++ b/tests/orthanc/orthanc-for-test.Dockerfile
@@ -1,4 +1,4 @@
-FROM orthancteam/orthanc:24.12.0
+FROM orthancteam/orthanc:25.2.0
 
 RUN pip install httpx pydicom  --break-system-packages
 

--- a/tests/orthanc/pytest.Dockerfile
+++ b/tests/orthanc/pytest.Dockerfile
@@ -11,4 +11,4 @@ RUN poetry install --extras "all" --no-root
 
 COPY ../.. /app
 
-ENTRYPOINT [ "poetry", "run", "pytest", "-vv" ]
+ENTRYPOINT [ "poetry", "run", "pytest", "-vv", "tests/test_modality.py::test_get"]

--- a/tests/test_modality.py
+++ b/tests/test_modality.py
@@ -55,6 +55,28 @@ def test_failed_find(modality):
         modality.find(bad_payload)
 
 
+def test_get(modality):
+    expected_move_answer = {
+        'Description': 'REST API',
+        'LocalAet': ORTHANC_1.AeT,
+        'RemoteAet': ORTHANC_2.AeT,
+        'Query': [{
+            '0008,0052': 'STUDY',
+            '0020,000d': '1.3.6.1.4.1.22213.2.6291.2.1'
+        }],
+    }
+    setup_data(ORTHANC_2)
+
+    result = modality.get(level='Study', resources={'StudyInstanceUID': '1.3.6.1.4.1.22213.2.6291.2.1'})
+
+    assert result == expected_move_answer
+    resulting_patient_information = modality.client.get_patients_id(
+        modality.client.get_patients()[0]
+    )
+    assert {k: v for k, v in PATIENT_INFORMATION.items() if k not in ['LastUpdate']} == \
+           {k: v for k, v in resulting_patient_information.items() if k not in ['LastUpdate']}
+
+
 def test_move(modality):
     expected_move_answer = {
         'Description': 'REST API',


### PR DESCRIPTION
- `Orthanc` and `AsyncOrthanc` updated to support Orthanc 1.12.6
- Add `Modality.get` method, that use the newly added [C-GET](https://orthanc.uclouvain.be/api/#tag/Networking/paths/~1modalities~1{id}~1get/post) endpoint
- Bump PyOrthanc version to 1.20.0