### PR TITLE
✨ Add check_before_upload option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ upload(client, 'image.dcm')  # From a file
 upload(client, 'dicom_files.zip')  # From a zip
 upload(client, 'path/to/directory')  # Upload all dicom files in a directory
 upload(client, 'path/to/directory', recursive=True)  # Upload all dicom files in a directory recursively
+# Check if dicom is in Orthanc before upload
+upload(client, 'path/to/directory', recursive=True, check_before_upload=True)
 ```
 
 ## Working with DICOM Modalities

--- a/docs/api/upload.md
+++ b/docs/api/upload.md
@@ -1,0 +1,46 @@
+# Upload
+
+The Orthanc REST API is commonly used to upload DICOM files.
+To do so, you can use the `upload()` function.
+
+```python
+from pyorthanc import Orthanc, upload
+
+orthanc = Orthanc(url='http://localhost:8042')
+
+# The file can be a DICOM file, a zip file containing one or multiple DICOM
+upload(orthanc, 'dicom_filepath.dcm')
+
+# You can also upload a zip file containing one or multiple DICOM
+upload(orthanc, 'dicoms.zip')
+
+# A directory path can be also used. All DICOM files from the directory will be uploaded
+upload(orthanc, 'directory/path')
+upload(orthanc, 'directory/path', recursive=True)  # For nested dicom files
+
+# Note that `upload` returns a list of the uploaded instances `list[pyorthanc.Instance]`
+instances = upload(orthanc, 'directory/path')
+print(instances)
+```
+
+## Avoid uploading the same file twice
+DICOM files are often big, and uploading them multiple times can be time-consuming.
+To avoid uploading the same file twice, you can use the `check_before_upload` option.
+
+Note that ZIP files will always be re-uploaded.
+
+```python
+from pyorthanc import Orthanc, upload
+
+orthanc = Orthanc(url='http://localhost:8042')
+
+# For each DICOM file, it will check if the file is in Orthanc before uploading it.
+upload(orthanc, 'directory/path', recursive=True, check_before_upload=True)
+```
+
+## Reference
+::: pyorthanc._upload
+options:
+members: true
+:docstring:
+:members:

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,8 @@ upload(client, 'image.dcm')  # From a file
 upload(client, 'dicom_files.zip')  # From a zip
 upload(client, 'path/to/directory')  # Upload all dicom files in a directory
 upload(client, 'path/to/directory', recursive=True)  # Upload all dicom files in a directory recursively
+# Check if dicom is in Orthanc before upload
+upload(client, 'path/to/directory', recursive=True, check_before_upload=True)
 ```
 ## Working with DICOM Modalities
 

--- a/pyorthanc/_upload.py
+++ b/pyorthanc/_upload.py
@@ -2,16 +2,20 @@ import glob
 import os
 from io import BytesIO
 from pathlib import Path
-from typing import Dict, Generator, Union
+from typing import Dict, Generator, List, Union
 
 import httpx
 import pydicom
 
-from pyorthanc import AsyncOrthanc, Orthanc
-from pyorthanc.util import to_orthanc_study_id, to_orthanc_series_id, to_orthanc_patient_id, to_orthanc_instance_id_from_ds
+from pyorthanc import AsyncOrthanc, Instance, Orthanc
+from pyorthanc.util import ensure_non_raw_response, to_orthanc_instance_id_from_ds
 
 
-def upload(client: Orthanc, path_or_ds: Union[str, Path, pydicom.Dataset], recursive: bool = False, check_before_upload: bool = False) -> Union[Dict, httpx.Response]:
+def upload(
+        client: Orthanc,
+        path_or_ds: Union[str, Path, pydicom.Dataset],
+        recursive: bool = False,
+        check_before_upload: bool = False) -> List[Instance]:
     """Upload a DICOM file or dataset to Orthanc synchronously
 
     Parameters
@@ -25,19 +29,46 @@ def upload(client: Orthanc, path_or_ds: Union[str, Path, pydicom.Dataset], recur
     check_before_upload : bool
          Verify if data is already in Orthanc before sending it. It verifies if a file is stored, there is no file comparison.
     """
-    if (isinstance(path_or_ds, str) or isinstance(path_or_ds, Path)) and os.path.isdir(path_or_ds):
-        for dicom_bytes in _prepare_data_directory(path_or_ds, recursive=recursive):
-            client.post_instances(dicom_bytes)
+    client = ensure_non_raw_response(client)
 
+    instances = []
+
+    # If path_or_ds is a directory, upload all the DICOM files in the directory.
+    if (isinstance(path_or_ds, str) or isinstance(path_or_ds, Path)) and os.path.isdir(path_or_ds):
+        for dicom_bytes in _generate_dicom_bytes_from_directory(path_or_ds, recursive=recursive):
+            if check_before_upload:
+                data_is_in_orthanc, instance = _is_data_already_in_orthanc(client, dicom_bytes)
+
+                # If data is already in Orthanc, skip uploading it and go to the next file.
+                if data_is_in_orthanc:
+                    instances.append(instance)
+                    continue
+
+            result = client.post_instances(dicom_bytes)
+            instance = Instance(result['ID'], client)
+            instances.append(instance)
+
+    # If path_or_ds is a DICOM file, zip file or a pydicom Dataset, upload it.
     else:
         dicom_bytes = _prepare_data_from_ds_or_file(path_or_ds)
 
         if check_before_upload:
-            data_in_orthanc, return_message = _is_data_already_in_orthanc(client, dicom_bytes)
+            data_in_orthanc, instance = _is_data_already_in_orthanc(client, dicom_bytes)
+            # If data is already in Orthanc, returns the instance directly.
             if data_in_orthanc:
-                return return_message
+                instances.append(instance)
+                return instances
 
-        return client.post_instances(dicom_bytes)
+        result = client.post_instances(dicom_bytes)
+
+        # When a zip is uploaded, result can be a list of instances if the zip contained multiple DICOM files.
+        if isinstance(result, list):
+            instances += [Instance(i['ID'], client) for i in result]
+        else:
+            instance = Instance(result['ID'], client)
+            instances.append(instance)
+
+    return instances
 
 
 async def async_upload(client: AsyncOrthanc, path_or_ds: Union[str, Path, pydicom.Dataset]) -> Union[Dict, httpx.Response]:
@@ -60,17 +91,19 @@ def _prepare_data_from_ds_or_file(path_or_ds: Union[str, Path, pydicom.Dataset])
     if isinstance(path_or_ds, str) or isinstance(path_or_ds, Path):
         with open(path_or_ds, 'rb') as f:
             dicom_bytes = f.read()
+
     elif isinstance(path_or_ds, pydicom.Dataset):
         buffer = BytesIO()
         path_or_ds.save_as(buffer)
         dicom_bytes = buffer.getvalue()
+
     else:
-        raise TypeError("path_or_ds must be either a file path or pydicom Dataset")
+        raise TypeError('path_or_ds must be either a file path or pydicom Dataset')
 
     return dicom_bytes
 
 
-def _prepare_data_directory(directory: str, recursive: bool) -> Generator[bytes, None, None]:
+def _generate_dicom_bytes_from_directory(directory: str, recursive: bool) -> Generator[bytes, None, None]:
     filepaths = glob.glob(os.path.join(directory, '*.dcm'))
     filepaths += glob.glob(os.path.join(directory, '*.DCM'))
     filepaths += glob.glob(os.path.join(directory, '*.dcm.gz'))
@@ -94,21 +127,9 @@ def _is_data_already_in_orthanc(client: Orthanc, dicom_bytes):
     orthanc_id = to_orthanc_instance_id_from_ds(ds)
 
     try:
+        # Attempt to get metadata to verify if data is already in Orthanc.
         client.get_instances_id_metadata(id_=orthanc_id)
+        return True, Instance(orthanc_id, client)
 
-        return True, _make_already_stored_return_message(ds)
-    except httpx.HTTPError as e:
+    except httpx.HTTPError:
         return False, ''
-
-
-def _make_already_stored_return_message(ds):
-    instance_id = to_orthanc_instance_id_from_ds(ds)
-
-    data = {'ID': instance_id,
-            'ParentPatient': to_orthanc_patient_id(ds.PatientID),
-            'ParentSeries': to_orthanc_series_id(ds.PatientID, ds.StudyInstanceUID, ds.SeriesInstanceUID),
-            'ParentStudy': to_orthanc_study_id(ds.PatientID, ds.StudyInstanceUID),
-            'Path': f'/instances/{instance_id}',
-            'Status': 'AlreadyStored'}
-
-    return data

--- a/pyorthanc/_upload.py
+++ b/pyorthanc/_upload.py
@@ -8,9 +8,10 @@ import httpx
 import pydicom
 
 from pyorthanc import AsyncOrthanc, Orthanc
+from pyorthanc.util import _make_orthanc_id, to_orthanc_study_id, to_orthanc_series_id, to_orthanc_patient_id
 
 
-def upload(client: Orthanc, path_or_ds: Union[str, Path, pydicom.Dataset], recursive: bool = False) -> Union[Dict, httpx.Response]:
+def upload(client: Orthanc, path_or_ds: Union[str, Path, pydicom.Dataset], recursive: bool = False, check_before_upload: bool = False) -> Union[Dict, httpx.Response]:
     """Upload a DICOM file or dataset to Orthanc synchronously
 
     Parameters
@@ -21,6 +22,8 @@ def upload(client: Orthanc, path_or_ds: Union[str, Path, pydicom.Dataset], recur
         Either a path to a DICOM file, directory, zip file or a pydicom Dataset object
     recursive : bool
         When `path_or_ds` is a directory, whether to upload recursively all the DICOM files in the directory
+    check_before_upload : bool
+         Verify if data is already in Orthanc before sending it. It verifies if a file is stored, there is no file comparison.
     """
     if (isinstance(path_or_ds, str) or isinstance(path_or_ds, Path)) and os.path.isdir(path_or_ds):
         for dicom_bytes in _prepare_data_directory(path_or_ds, recursive=recursive):
@@ -28,6 +31,11 @@ def upload(client: Orthanc, path_or_ds: Union[str, Path, pydicom.Dataset], recur
 
     else:
         dicom_bytes = _prepare_data_from_ds_or_file(path_or_ds)
+
+        if check_before_upload:
+            data_in_orthanc, return_message = _is_data_already_in_orthanc(client, dicom_bytes)
+            if data_in_orthanc:
+                return return_message
 
         return client.post_instances(dicom_bytes)
 
@@ -78,3 +86,34 @@ def _prepare_data_directory(directory: str, recursive: bool) -> Generator[bytes,
 
     for filepath in filepaths:
         yield _prepare_data_from_ds_or_file(filepath)
+
+
+def _is_data_already_in_orthanc(client: Orthanc, dicom_bytes):
+    dicom_file_like = BytesIO(dicom_bytes)
+    ds = pydicom.dcmread(dicom_file_like)
+    orthanc_id = _make_orthanc_id_from_ds(ds)
+
+    try:
+        info = client.get_instances_id_metadata(id_=orthanc_id)
+
+        return True, _make_already_stored_return_message(ds)
+    except httpx.HTTPError as e:
+        return False, ''
+
+
+def _make_orthanc_id_from_ds(ds: pydicom.Dataset):
+    return _make_orthanc_id(patient_id=ds.PatientID, study_uid=ds.StudyInstanceUID, series_uid=ds.SeriesInstanceUID,
+                            instance_uid=ds.SOPInstanceUID)
+
+
+def _make_already_stored_return_message(ds):
+    instance_id = _make_orthanc_id_from_ds(ds)
+
+    data = {'ID': instance_id,
+            'ParentPatient': to_orthanc_patient_id(ds.PatientID),
+            'ParentSeries': to_orthanc_series_id(ds.PatientID, ds.StudyInstanceUID, ds.SeriesInstanceUID),
+            'ParentStudy': to_orthanc_study_id(ds.PatientID, ds.StudyInstanceUID),
+            'Path': f'/instances/{instance_id}',
+            'Status': 'AlreadyStored'}
+
+    return data

--- a/pyorthanc/util.py
+++ b/pyorthanc/util.py
@@ -62,7 +62,7 @@ def get_pydicom(orthanc: Orthanc, instance_identifier: str) -> pydicom.FileDatas
     """Get a pydicom.FileDataset from the instance's Orthanc identifier"""
     dicom_bytes = orthanc.get_instances_id_file(instance_identifier)
 
-    return pydicom.dcmread(BytesIO(dicom_bytes))
+    return pydicom.dcmread(BytesIO(dicom_bytes), force=False)
 
 
 def ensure_non_raw_response(client: Orthanc) -> Orthanc:
@@ -91,6 +91,11 @@ def to_orthanc_series_id(patient_id: str, study_uid: str, series_uid: str) -> st
 
 def to_orthanc_instance_id(patient_id: str, study_uid: str, series_uid: str, instance_uid) -> str:
     return _make_orthanc_id(patient_id, study_uid, series_uid, instance_uid)
+
+
+def to_orthanc_instance_id_from_ds(ds: pydicom.Dataset) -> str:
+    return _make_orthanc_id(patient_id=ds.PatientID, study_uid=ds.StudyInstanceUID, series_uid=ds.SeriesInstanceUID,
+                            instance_uid=ds.SOPInstanceUID)
 
 
 def _make_orthanc_id(patient_id: str, study_uid: str = None, series_uid: str = None, instance_uid: str = None) -> str:

--- a/pyorthanc/util.py
+++ b/pyorthanc/util.py
@@ -62,7 +62,7 @@ def get_pydicom(orthanc: Orthanc, instance_identifier: str) -> pydicom.FileDatas
     """Get a pydicom.FileDataset from the instance's Orthanc identifier"""
     dicom_bytes = orthanc.get_instances_id_file(instance_identifier)
 
-    return pydicom.dcmread(BytesIO(dicom_bytes), force=False)
+    return pydicom.dcmread(BytesIO(dicom_bytes))
 
 
 def ensure_non_raw_response(client: Orthanc) -> Orthanc:

--- a/pyorthanc/util.py
+++ b/pyorthanc/util.py
@@ -94,8 +94,12 @@ def to_orthanc_instance_id(patient_id: str, study_uid: str, series_uid: str, ins
 
 
 def to_orthanc_instance_id_from_ds(ds: pydicom.Dataset) -> str:
-    return _make_orthanc_id(patient_id=ds.PatientID, study_uid=ds.StudyInstanceUID, series_uid=ds.SeriesInstanceUID,
-                            instance_uid=ds.SOPInstanceUID)
+    return _make_orthanc_id(
+        patient_id=ds.PatientID,
+        study_uid=ds.StudyInstanceUID,
+        series_uid=ds.SeriesInstanceUID,
+        instance_uid=ds.SOPInstanceUID
+    )
 
 
 def _make_orthanc_id(patient_id: str, study_uid: str = None, series_uid: str = None, instance_uid: str = None) -> str:

--- a/tests/test_internal_client.py
+++ b/tests/test_internal_client.py
@@ -20,4 +20,6 @@ def test_route_with_internal_client(client):
     assert response.status_code == HTTPStatus.OK
     result = response.json()
     assert 'modalities' in result
-    assert result['modalities'] == ['RTDOSE', 'RTPLAN', 'RTSTRUCT']
+    assert 'RTDOSE' in result['modalities']
+    assert 'RTPLAN' in result['modalities']
+    assert 'RTSTRUCT' in result['modalities']

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -13,8 +13,9 @@ def test_upload_with_path(client):
     assert len(client.get_patients()) == 0
     path = get_testdata_file('CT_small.dcm')
 
-    upload(client, path)
+    instances = upload(client, path)
 
+    assert len(instances) == 1
     assert len(client.get_patients()) == 1
 
 
@@ -22,8 +23,9 @@ def test_upload_with_ds(client):
     assert len(client.get_patients()) == 0
     ds = pydicom.dcmread(get_testdata_file('CT_small.dcm'))
 
-    upload(client, ds)
+    instances = upload(client, ds)
 
+    assert len(instances) == 1
     assert len(client.get_patients()) == 1
 
 
@@ -38,8 +40,9 @@ def test_upload_with_zip(client):
             zipf.write(ct_file_path, os.path.basename(ct_file_path))
             zipf.write(mr_file_path, os.path.basename(mr_file_path))
 
-        upload(client, zip_filepath)
+        instances = upload(client, zip_filepath)
 
+    assert len(instances) == 2
     assert len(client.get_patients()) == 2
 
 
@@ -57,10 +60,12 @@ def test_upload_with_directory(client):
         shutil.copy(mr_file_path, os.path.join(tmpdirname, 'mr', 'MR_small.dcm'))
         shutil.copy(ct_file_path, os.path.join(tmpdirname, 'ct', 'other-dir', 'CT_small.dcm'))
 
-        upload(client, tmpdirname)
+        instances = upload(client, tmpdirname)
         # Only one patient since only rtplan.dcm is in a direct directory
+        assert len(instances) == 1
         assert len(client.get_patients()) == 1
 
         # Upload everything
-        upload(client, tmpdirname, recursive=True)
+        instances = upload(client, tmpdirname, recursive=True)
+        assert len(instances) == 3
         assert len(client.get_patients()) == 3

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -2,7 +2,9 @@ import os
 import shutil
 import tempfile
 import zipfile
+from unittest.mock import patch
 
+import httpx
 import pydicom
 import pytest
 from pydicom.data import get_testdata_file
@@ -96,3 +98,20 @@ def test_upload_with_directory_without_dicom(client):
 
     assert len(instances) == 0
     assert len(client.get_patients()) == 0
+
+
+def test_upload_while_checking_if_instance_exists(client):
+    path = get_testdata_file('CT_small.dcm')
+
+    with patch('pyorthanc.client.Orthanc.get_instances_id_metadata') as mock_get_instance:
+        with patch('pyorthanc.client.Orthanc.post_instances', return_value={'ID': 'test-instance-id'}) as mock_post_instances:
+            mock_get_instance.side_effect = httpx.HTTPError('Instance already exists')
+            instances = upload(client, path, check_before_upload=True)
+            assert len(instances) == 1
+
+            mock_get_instance.side_effect = None
+            instances = upload(client, path, check_before_upload=True)
+            assert len(instances) == 1
+
+            assert mock_post_instances.call_count == 1  # Should only be called once
+            assert mock_get_instance.call_count == 2  # Call 2 times to check if an instance exists before upload


### PR DESCRIPTION
Add possibility to check if a file is already in Orthanc before uploading it (useful for large file).

[Breaking changes]
- `upload()` now returns a list of instances `list[pyorthanc.Instance]` rather than the `Orthanc.post_instances()` response.