### PR TITLE
🐛 Remove warning when importing pyorthanc

### DIFF
--- a/pyorthanc/_internal_client.py
+++ b/pyorthanc/_internal_client.py
@@ -1,6 +1,6 @@
 import json
 
-from . import Orthanc, orthanc_sdk
+from . import Orthanc
 from .errors import NotInInternalEnvironmentError
 
 
@@ -26,6 +26,8 @@ def get_internal_client() -> Orthanc:
     ...
     ... orthanc_sdk.RegisterRestCallback('/get-modalities-in-orthanc', get_modalities_in_orthanc)
     """
+    from pyorthanc import orthanc_sdk
+
     config = orthanc_sdk.GetConfiguration()
 
     if not config:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyorthanc"
-version = "1.22.0"
+version = "1.22.1"
 description = "Orthanc REST API python wrapper with additional utilities"
 authors = [
     "Gabriel Couture <gacou54@gmail.com>",


### PR DESCRIPTION
In Pyorthanc 1.22.0, normally importing pyorthanc produces a warning. This PR removes this warning.
