### PR TITLE
fix(docs): quickstart parameters for ` get_query_answers()`

### DIFF
--- a/docs/tutorial/quickstart.md
+++ b/docs/tutorial/quickstart.md
@@ -52,7 +52,7 @@ data = {'Level': 'Study', 'Query': {'PatientID': '*'}}
 query_response = modality.query(data=data)
 
 # Inspect the answer
-answer = modality.get_query_answers()[query_response['ID']]
+answer = modality.get_query_answers(query_response['ID'])
 print(answer)
 
 # Retrieve (C-Move) results of query on a Orthanc itself, or to a target modality (AET)


### PR DESCRIPTION
This fixes a syntax error in the quickstart examples