### PR TITLE
✨ Add the force option when upload problematic DICOM file

### DIFF
--- a/pyorthanc/_upload.py
+++ b/pyorthanc/_upload.py
@@ -16,7 +16,8 @@ def upload(
         client: Orthanc,
         path_or_ds: Union[str, Path, pydicom.Dataset],
         recursive: bool = False,
-        check_before_upload: bool = False) -> List[Instance]:
+        check_before_upload: bool = False,
+        force: bool = False) -> List[Instance]:
     """Upload a DICOM file or dataset to Orthanc synchronously
 
     Parameters
@@ -29,6 +30,8 @@ def upload(
         When `path_or_ds` is a directory, whether to upload recursively all the DICOM files in the directory
     check_before_upload : bool
          Verify if data is already in Orthanc before sending it. It verifies if a file is stored, there is no file comparison.
+    force : bool
+        Force the read of the DICOM file (for pydicom.dcmread)
     """
     client = ensure_non_raw_response(client)
 
@@ -38,7 +41,7 @@ def upload(
     if (isinstance(path_or_ds, str) or isinstance(path_or_ds, Path)) and os.path.isdir(path_or_ds):
         for dicom_bytes in _generate_dicom_bytes_from_directory(path_or_ds, recursive=recursive):
             if check_before_upload:
-                data_is_in_orthanc, instance = _is_data_already_in_orthanc(client, dicom_bytes)
+                data_is_in_orthanc, instance = _is_data_already_in_orthanc(client, dicom_bytes, force)
 
                 # If data is already in Orthanc, skip uploading it and go to the next file.
                 if data_is_in_orthanc:
@@ -54,7 +57,7 @@ def upload(
         dicom_bytes = _prepare_data_from_ds_or_file(path_or_ds)
 
         if check_before_upload:
-            data_in_orthanc, instance = _is_data_already_in_orthanc(client, dicom_bytes)
+            data_in_orthanc, instance = _is_data_already_in_orthanc(client, dicom_bytes, force)
             # If data is already in Orthanc, returns the instance directly.
             if data_in_orthanc:
                 instances.append(instance)
@@ -72,7 +75,10 @@ def upload(
     return instances
 
 
-async def async_upload(client: AsyncOrthanc, path_or_ds: Union[str, Path, pydicom.Dataset]) -> Union[Dict, httpx.Response]:
+async def async_upload(
+        client: AsyncOrthanc,
+        path_or_ds: Union[str, Path, pydicom.Dataset],
+        force: bool = False) -> Union[Dict, httpx.Response]:
     """Upload a DICOM file or dataset to Orthanc asynchronously
 
     Parameters
@@ -81,6 +87,8 @@ async def async_upload(client: AsyncOrthanc, path_or_ds: Union[str, Path, pydico
         The async Orthanc client to use for upload
     path_or_ds : Union[str, Path, pydicom.Dataset]
         Either a path to a DICOM file, zip file or a pydicom Dataset object
+    force : bool
+        Force the read of the DICOM file (for pydicom.dcmread), only used if dataset is not provided.
     """
     dicom_bytes = _prepare_data_from_ds_or_file(path_or_ds)
 
@@ -122,10 +130,10 @@ def _generate_dicom_bytes_from_directory(directory: str, recursive: bool) -> Gen
         yield _prepare_data_from_ds_or_file(filepath)
 
 
-def _is_data_already_in_orthanc(client: Orthanc, dicom_bytes: bytes) -> Tuple[bool, Union[Instance, None]]:
+def _is_data_already_in_orthanc(client: Orthanc, dicom_bytes: bytes, force: bool = False) -> Tuple[bool, Union[Instance, None]]:
     try:
         dicom_file_like = BytesIO(dicom_bytes)
-        ds = pydicom.dcmread(dicom_file_like)
+        ds = pydicom.dcmread(dicom_file_like, force=force)
         orthanc_id = to_orthanc_instance_id_from_ds(ds)
     except InvalidDicomError:
         # If the file is not a valid DICOM file, likely it is a zip file. It will be uploaded.

--- a/pyorthanc/_upload.py
+++ b/pyorthanc/_upload.py
@@ -78,7 +78,9 @@ def upload(
 async def async_upload(
         client: AsyncOrthanc,
         path_or_ds: Union[str, Path, pydicom.Dataset],
-        force: bool = False) -> Union[Dict, httpx.Response]:
+        recursive: bool = False,
+        check_before_upload: bool = False,
+        force: bool = False) -> List[Instance]:
     """Upload a DICOM file or dataset to Orthanc asynchronously
 
     Parameters
@@ -86,13 +88,75 @@ async def async_upload(
     client : AsyncOrthanc
         The async Orthanc client to use for upload
     path_or_ds : Union[str, Path, pydicom.Dataset]
-        Either a path to a DICOM file, zip file or a pydicom Dataset object
+        Either a path to a DICOM file, directory, zip file or a pydicom Dataset object
+    recursive : bool
+        When `path_or_ds` is a directory, whether to upload recursively all the DICOM files in the directory
+    check_before_upload : bool
+         Verify if data is already in Orthanc before sending it. It verifies if a file is stored, there is no file comparison.
     force : bool
         Force the read of the DICOM file (for pydicom.dcmread), only used if dataset is not provided.
     """
-    dicom_bytes = _prepare_data_from_ds_or_file(path_or_ds)
+    client = ensure_non_raw_response(client)
 
-    return await client.post_instances(dicom_bytes)
+    instances = []
+
+    # If path_or_ds is a directory, upload all the DICOM files in the directory.
+    if (isinstance(path_or_ds, str) or isinstance(path_or_ds, Path)) and os.path.isdir(path_or_ds):
+        for dicom_bytes in _generate_dicom_bytes_from_directory(path_or_ds, recursive=recursive):
+            if check_before_upload:
+                data_is_in_orthanc, instance = await _async_is_data_already_in_orthanc(client, dicom_bytes, force)
+
+                # If data is already in Orthanc, skip uploading it and go to the next file.
+                if data_is_in_orthanc:
+                    instances.append(instance)
+                    continue
+
+            result = await client.post_instances(dicom_bytes)
+            instance = Instance(result['ID'], client)
+            instances.append(instance)
+
+    # If path_or_ds is a DICOM file, zip file or a pydicom Dataset, upload it.
+    else:
+        dicom_bytes = _prepare_data_from_ds_or_file(path_or_ds)
+
+        if check_before_upload:
+            data_in_orthanc, instance = await _async_is_data_already_in_orthanc(client, dicom_bytes, force)
+            # If data is already in Orthanc, returns the instance directly.
+            if data_in_orthanc:
+                instances.append(instance)
+                return instances
+
+        result = await client.post_instances(dicom_bytes)
+
+        # When a zip is uploaded, result can be a list of instances if the zip contained multiple DICOM files.
+        if isinstance(result, list):
+            instances += [Instance(i['ID'], client) for i in result]
+        else:
+            instance = Instance(result['ID'], client)
+            instances.append(instance)
+
+    return instances
+
+
+async def _async_is_data_already_in_orthanc(
+        client: AsyncOrthanc,
+        dicom_bytes: bytes,
+        force: bool = False) -> Tuple[bool, Union[Instance, None]]:
+    try:
+        dicom_file_like = BytesIO(dicom_bytes)
+        ds = pydicom.dcmread(dicom_file_like, force=force)
+        orthanc_id = to_orthanc_instance_id_from_ds(ds)
+    except InvalidDicomError:
+        # If the file is not a valid DICOM file, likely it is a zip file. It will be uploaded.
+        return False, None
+
+    try:
+        # Attempt to get metadata to verify if data is already in Orthanc.
+        await client.get_instances_id_metadata(id_=orthanc_id)
+        return True, Instance(orthanc_id, client)
+
+    except httpx.HTTPError:
+        return False, None
 
 
 def _prepare_data_from_ds_or_file(path_or_ds: Union[str, Path, pydicom.Dataset]) -> bytes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ jinja2 = "^3.1.2"
 [tool.poetry.group.dev.dependencies]
 pytest = "^9"
 simple-openapi-client = "^0.5.4"
+pytest-asyncio = "^1.3.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/test_async_upload.py
+++ b/tests/test_async_upload.py
@@ -1,0 +1,118 @@
+import os
+import tempfile
+import zipfile
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pydicom
+import pytest
+from pydicom.data import get_testdata_file
+
+from pyorthanc import Instance, async_upload
+
+
+@pytest.mark.asyncio
+async def test_async_upload_with_path(async_client):
+    path = get_testdata_file('CT_small.dcm')
+
+    result = await async_upload(async_client, path)
+
+    assert isinstance(result, list)
+    assert isinstance(result[0], Instance)
+    assert result[0].id_ == 'f689ddd2-662f8fe1-8b18180d-ec2a2cee-937917af'
+
+
+@pytest.mark.asyncio
+async def test_async_upload_with_ds(async_client):
+    ds = pydicom.dcmread(get_testdata_file('CT_small.dcm'))
+
+    result = await async_upload(async_client, ds)
+
+    assert isinstance(result, list)
+    assert isinstance(result[0], Instance)
+    assert result[0].id_ == 'f689ddd2-662f8fe1-8b18180d-ec2a2cee-937917af'
+
+
+@pytest.mark.asyncio
+async def test_async_upload_with_zip(async_client):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        ct_file_path = get_testdata_file('CT_small.dcm')
+        mr_file_path = get_testdata_file('MR_small.dcm')
+
+        zip_filepath = os.path.join(tmpdirname, 'dicom_files.zip')
+        with zipfile.ZipFile(zip_filepath, 'w') as zipf:
+            zipf.write(ct_file_path, os.path.basename(ct_file_path))
+            zipf.write(mr_file_path, os.path.basename(mr_file_path))
+
+        result = await async_upload(async_client, zip_filepath)
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert all(isinstance(i, Instance) for i in result)
+
+
+@pytest.mark.asyncio
+async def test_async_upload_with_directory(async_client):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        rtplan_file_path = get_testdata_file('rtplan.dcm')
+        mr_file_path = get_testdata_file('MR_small.dcm')
+        ct_file_path = get_testdata_file('CT_small.dcm')
+
+        for file_path in [rtplan_file_path, mr_file_path, ct_file_path]:
+            with open(file_path, 'rb') as f:
+                with open(os.path.join(tmpdirname, os.path.basename(file_path)), 'wb') as f2:
+                    f2.write(f.read())
+
+        result = await async_upload(async_client, tmpdirname)
+
+    assert isinstance(result, list)
+    assert len(result) == 3
+    assert all(isinstance(i, Instance) for i in result)
+
+
+@pytest.mark.asyncio
+async def test_async_upload_with_bad_path(async_client):
+    with pytest.raises(FileNotFoundError):
+        await async_upload(async_client, 'bad/path')
+
+
+@pytest.mark.asyncio
+async def test_async_upload_with_zip_without_dicom(async_client):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        non_dicom_file_path = __file__
+
+        zip_filepath = os.path.join(tmpdirname, 'non_dicom_files.zip')
+        with zipfile.ZipFile(zip_filepath, 'w') as zipf:
+            zipf.write(non_dicom_file_path, os.path.basename(non_dicom_file_path))
+
+        result = await async_upload(async_client, zip_filepath)
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_async_upload_with_directory_without_dicom(async_client, tmp_dir):
+    result = await async_upload(async_client, tmp_dir)
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_async_upload_while_checking_if_instance_exists(async_client):
+    path = get_testdata_file('CT_small.dcm')
+
+    with patch('pyorthanc.async_client.AsyncOrthanc.get_instances_id_metadata', new_callable=AsyncMock) as mock_get_instance:
+        with patch('pyorthanc.async_client.AsyncOrthanc.post_instances', new_callable=AsyncMock) as mock_post_instances:
+            mock_post_instances.return_value = {'ID': 'test-instance-id'}
+
+            mock_get_instance.side_effect = httpx.HTTPError('Instance already exists')
+            instances = await async_upload(async_client, path, check_before_upload=True)
+            assert len(instances) == 1
+
+            mock_get_instance.side_effect = None
+            mock_get_instance.return_value = {}  # Success
+            instances = await async_upload(async_client, path, check_before_upload=True)
+            assert len(instances) == 1
+
+            assert mock_post_instances.call_count == 1  # Should only be called once
+            assert mock_get_instance.call_count == 2  # Call 2 times to check if an instance exists before upload


### PR DESCRIPTION
* Add the `force` parameter to `upload()` to attempt to handle problematic DICOM files
  - The `force` parameter is pass to the `pydicom.dcmread(..., force)` funciton call
* `async_upload()` has now the same behavior of `upload()`, but async  

Related to #86 